### PR TITLE
pushing corrrect value for dac test

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -50,6 +50,7 @@ Describe 'Testing access to backup path' -Tags Storage, DISA, $filename {
 }
 
 Describe 'Testing DAC' -Tags DAC, $filename {
+    $dac = Get-DbcConfigValue policy.dacallowed
     (Get-SqlInstance).ForEach{
         Context "Testing $psitem" {
 			It "$psitem Should have DAC enabled $dac" {


### PR DESCRIPTION
Fixes #36 by setting up $dac from the config values.

Think I'm doing this right ;)