### PR TITLE
Use Connect-DbaInstance instead of Connect-DbaSqlServer

### DIFF
--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -37,7 +37,7 @@ Describe "Failsafe Operator" -Tags FailsafeOperator, Operator, $filename {
 		Context "Testing failsafe operator exists on $psitem" {
 			$failsafeoperator = Get-DbcConfigValue  agent.failsafeoperator
 			It "failsafe operator is $failsafeoperator" {
-				(Connect-DbaSqlServer -SqlInstance $psitem).JobServer.AlertSystem.FailSafeOperator | Should be $failsafeoperator
+				(Connect-DbaInstance -SqlInstance $psitem).JobServer.AlertSystem.FailSafeOperator | Should be $failsafeoperator
 			}
 		}
 	}


### PR DESCRIPTION
This will avoid warning on output

```
    Context Testing failsafe operator exists on localhost
WARNING: [Connect-DbaInstance][09:27:30] Using the alias Connect-DbaSqlServer is deprecated. This alias will be removed in version 1.0.0, use Connect-DbaInstance instead
      [-] failsafe operator is  22.69s
        Expected: {}
        But was:  {DB eAlert}
        40:                 (Connect-DbaSqlServer -SqlInstance $psitem).JobServer.AlertSystem.FailSafeOperator | Should be $failsafeoperator
        at Invoke-LegacyAssertion, C:\Program Files\WindowsPowerShell\Modules\Pester\4.1.1\Functions\Assertions\Should.ps1: line 190
        at <ScriptBlock>, C:\Program Files\WindowsPowerShell\Modules\dbachecks\checks\Agent.Tests.ps1: line 40
```

Thanks @js0505 