### PR TITLE
Added DB Trustworthy Test

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -324,11 +324,11 @@ Describe "Datafile Auto Growth Configuration" -Tags DatafileAutoGrowthType, $fil
 	}
 }
 
-Describe "Database trustworthy option" -Tags TrustworthyOption, DISA, $filename {
+Describe "Database trustworthy option" -Tags Trustworthy, DISA, $filename {
 	(Get-SqlInstance).ForEach{
 		Context "Testing database trustworthy option on $psitem" {
 			@(Get-DbaDatabase -SqlInstance $psitem -ExcludeDatabase msdb).ForEach{
-				It "$($psitem.Trustworthy) should return trustworthy option False databases on $($psitem.SqlInstance)" {
+				It "$($psitem.Trustworthy) should return trustworthy option False databases on $($psitem.Name)" {
 					$psitem.Trustworthy | Should Be $false
 				}
 			}


### PR DESCRIPTION
Added database test to see if Trustworthy option is disabled.  Best practice shows it should be disabled on all but msdb.