### PR TITLE
Invoke-DbcCheck - Updating dynamic parameter naming / casing

### DIFF
--- a/functions/Invoke-DbcCheck.ps1
+++ b/functions/Invoke-DbcCheck.ps1
@@ -208,14 +208,16 @@
 		$RuntimeParamDic = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 		
 		foreach ($setting in $config) {
+			$name = $setting.Name
+			$name = "Config" + (($name.Split(".") | ForEach-Object { $_.SubString(0, 1).ToUpper() + $_.SubString(1) }) -join '')
 			$ParamAttrib = New-Object System.Management.Automation.ParameterAttribute
 			$ParamAttrib.ParameterSetName = '__AllParameterSets'
 			$AttribColl = New-Object  System.Collections.ObjectModel.Collection[System.Attribute]
 			$AttribColl.Add($ParamAttrib)
 			
-			$RuntimeParam = New-Object System.Management.Automation.RuntimeDefinedParameter("Config$($setting.Name.Replace('.',''))", [object], $AttribColl)
+			$RuntimeParam = New-Object System.Management.Automation.RuntimeDefinedParameter($name, [object], $AttribColl)
 			
-			$RuntimeParamDic.Add("Dbc$($setting.Name.Replace('.', ''))", $RuntimeParam)
+			$RuntimeParamDic.Add($name, $RuntimeParam)
 		}
 		return $RuntimeParamDic
 	}


### PR DESCRIPTION
## Changes

 - Changed parameter prefix from `Dbc` to `Config`
 - Introduced casing to dynamic parameters, causing each namespace element to start with an uppercase letter