### PR TITLE
added a check for null to the tags so that there can be an understandable failed test

### DIFF
--- a/tests/Unit.Tests.ps1
+++ b/tests/Unit.Tests.ps1
@@ -41,15 +41,21 @@ Describe "Checking that each dbachecks Pester test is correctly formatted for Po
                     $PsItem.Tags | Should Not BeNullOrEmpty
                 }
                 # a simple test for no esses apart from statistics and Access!!
-                $PSItem.Tags.Text.Split(',').Trim().Where{($_ -ne '$filename') -and ($_ -notlike '*statistics*') -and ($_ -notlike '*BackupPathAccess*') }.ForEach{
-                    It "$PsItem Should Be Singular" {
-                        $_.ToString().Endswith('s') | Should Be $False
+                if ($null -ne $PSItem.Tags) {
+                    $PSItem.Tags.Text.Split(',').Trim().Where{($_ -ne '$filename') -and ($_ -notlike '*statistics*') -and ($_ -notlike '*BackupPathAccess*') }.ForEach{
+                        It "$PsItem Should Be Singular" {
+                            $_.ToString().Endswith('s') | Should Be $False
+                        }
+                    }
+                    It "The first Tag Should Be in the unique Tags returned from Get-DbcCheck" {
+                        $UniqueTags -contains $PSItem.Tags.Text.Split(',')[0].ToString() | Should Be $true
                     }
                 }
-                It "The first Tag Should Be in the unique Tags returned from Get-DbcCheck" {
-                    $UniqueTags -contains $PSItem.Tags.Text.Split(',')[0].ToString() | Should Be $true
-                }
-       
+                else {
+                    It "You haven't used the Tags Parameter so we can't check the tags" {
+                        $false | Should be $true
+                    }
+                }  
             }
         }
         Context "$($_.Name) - Checking Contexts" {


### PR DESCRIPTION
Nothing changed except a better failure result if -Tag is used instead of -Tags. It was failing with a cannot index null so I changed it so it says  

You haven't used the Tags Parameter so we can't check the tags