### PR TITLE
Case/Grammar changes on AutoUpdate and AutoCreate Stats

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -372,7 +372,7 @@ Describe "Auto Update Statistics" -Tags AutoUpdateStatistics, $filename {
     }
 }
 
-Describe "Auto Update Statistics Asynchronously" -Tags autoupdatestatisticsasynchronously, $filename {
+Describe "Auto Update Statistics Asynchronously" -Tags AutoUpdateStatisticsAsynchronously, $filename {
     $autoupdatestatisticsasynchronously = Get-DbcConfigValue policy.autoupdatestatisticsasynchronously
     (Get-SqlInstance).ForEach{
         Context "Testing Auto Update Statistics Asynchronously on $psitem" {


### PR DESCRIPTION
There is no development branch so chose master, sorry if that is incorrect.

- Fixes #225, #224 - changing has to have
- Changed case of Tag autoupdatestatistics to AutoUpdateStatistics
- Changed case of Tag autoupdatestatisticsasynchronously to AutoUpdateStatisticsAsynchronously