### PR TITLE
Added test for "Optimize for Ad Hoc Workloads"

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -445,3 +445,15 @@ Describe "PseudoSimple Recovery Model" -Tags PseudoSimple, $filename {
         }
     }
 }
+
+Describe "Optimize for Ad Hoc Workloads" -Tags AdHocWorkloads, $filename {
+    (Get-SqlInstance).ForEach{
+        Context "Testing database has optimize for ad hoc workloads enabled on $psitem" {
+            @(Get-DbaDatabase -SqlInstance $psitem -ExcludeDatabase tempdb).ForEach{
+                It "$($psitem.Name) should have optimize for ad hoc workloads set to 1 on $($psitem.Parent)" {
+                    (Get-DbaSpConfigure -SqlInstance $psitem.Parent -Database $psitem.Name).RunningValue -eq 1 | Should be $true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Created a test to check for the sp_configure value of "Optimize for Ad Hoc Workloads" set to 1.

I couldn't see one already in the code and, from checking up on it, nearly everyone I checked with/post I read about it said that it should be enabled.

It's a bit of a bare bones test but that's because of it's widespread acceptance so I didn't create a config value for it. Creating the config code and changing the test to use it could be done if this is the decided way to go.

Let me know any thoughts...

P.S. _Yeah I know it's 23:00 on the Monday of code freeze...I'd love to blame my hectic schedule and all that but honestly I'm just a procrastinator_ 😞 