### PR TITLE
Get-SqlInstance should be an array even if it returns only one element

### DIFF
--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -1,7 +1,7 @@
 $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 
 Describe "SQL Agent Account" -Tags AgentServiceAccount, ServiceAccount, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing SQL Agent is running on $psitem" {
             @(Get-DbaSqlService -ComputerName $psitem -Type Agent).ForEach{
                 It "SQL Agent Should Be running on $psitem" {
@@ -16,7 +16,7 @@ Describe "SQL Agent Account" -Tags AgentServiceAccount, ServiceAccount, $filenam
 }
 
 Describe "DBA Operators" -Tags DbaOperator, Operator, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing DBA Operators exists on $psitem" {
             $operatorname = Get-DbcConfigValue agent.dbaoperatorname
             $operatoremail = Get-DbcConfigValue agent.dbaoperatoremail
@@ -38,7 +38,7 @@ Describe "DBA Operators" -Tags DbaOperator, Operator, $filename {
 }
 
 Describe "Failsafe Operator" -Tags FailsafeOperator, Operator, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing failsafe operator exists on $psitem" {
             $failsafeoperator = Get-DbcConfigValue agent.failsafeoperator
             It "failsafe operator on $psitem exists" {
@@ -49,7 +49,7 @@ Describe "Failsafe Operator" -Tags FailsafeOperator, Operator, $filename {
 }
 
 Describe "Database Mail Profile" -Tags DatabaseMailProfile, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing database mail profile is set on $psitem" {
             $databasemailprofile = Get-DbcConfigValue  agent.databasemailprofile
             It "database mail profile on $psitem is $databasemailprofile" {
@@ -60,7 +60,7 @@ Describe "Database Mail Profile" -Tags DatabaseMailProfile, $filename {
 }
 
 Describe "Failed Jobs" -Tags FailedJob, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Checking for failed enabled jobs on $psitem" {
             @(Get-DbaAgentJob -SqlInstance $psitem | Where-Object IsEnabled).ForEach{
                 if ($psitem.LastRunOutcome -eq "Unknown") {
@@ -80,7 +80,7 @@ Describe "Failed Jobs" -Tags FailedJob, $filename {
 
 Describe "Valid Job Owner" -Tags ValidJobOwner, $filename {
     $targetowner = Get-DbcConfigValue agent.validjobowner.name
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing job owners on $psitem" {
             @(Test-DbaJobOwner -SqlInstance $psitem -Login $targetowner -EnableException:$false).ForEach{
                 It "$($psitem.Job) owner Should Be $targetowner on $($psitem.Server)" {

--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -1,7 +1,7 @@
 $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 
 Describe "Database Collation" -Tags DatabaseCollation, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing database collation on $psitem" {
             @(Test-DbaDatabaseCollation -SqlInstance $psitem -ExcludeDatabase ReportingServer,ReportingServerTempDB ).ForEach{
                 It "database collation ($($psitem.DatabaseCollation)) should match server collation ($($psitem.ServerCollation)) for $($psitem.Database) on $($psitem.SqlInstance)" {
@@ -13,7 +13,7 @@ Describe "Database Collation" -Tags DatabaseCollation, $filename {
 }
 
 Describe "Suspect Page" -Tags SuspectPage, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing suspect pages on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 $results = Get-DbaSuspectPage -SqlInstance $psitem.Parent -Database $psitem.Name
@@ -30,7 +30,7 @@ Describe "Last Backup Restore Test" -Tags TestLastBackup, Backup, $filename {
         $destserver = Get-DbcConfigValue policy.backup.testserver 
         $destdata = Get-DbcConfigValue policy.backup.datadir
         $destlog = Get-DbcConfigValue policy.backup.logdir
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing Backup Restore & Integrity Checks on $psitem" {
                 @(Test-DbaLastBackup -SqlInstance $psitem -Destination $destserver -LogDirectory $destlog -DataDirectory $destdata).ForEach{
                     if ($psitem.DBCCResult -notmatch 'skipped for restored master') {
@@ -49,7 +49,7 @@ Describe "Last Backup Restore Test" -Tags TestLastBackup, Backup, $filename {
 
 Describe "Last Backup VerifyOnly" -Tags TestLastBackupVerifyOnly, Backup, $filename {
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod 
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "VerifyOnly tests of last backups on $psitem" {
             @(Test-DbaLastBackup -SqlInstance $psitem -Database (Get-DbaDatabase -SqlInstance $psitem | Where-Object {$_.CreateDate -lt (Get-Date).AddHours( - $graceperiod)}).name -VerifyOnly).ForEach{
                 It "restore for $($psitem.Database) on $($psitem.SourceServer) Should Be success" {
@@ -66,7 +66,7 @@ Describe "Last Backup VerifyOnly" -Tags TestLastBackupVerifyOnly, Backup, $filen
 Describe "Valid Database Owner" -Tags ValidDatabaseOwner, $filename {
     $targetowner = Get-DbcConfigValue policy.validdbowner.name
     $exclude = Get-DbcConfigValue policy.validdbowner.excludedb 
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Database Owners on $psitem" {
             @(Test-DbaDatabaseOwner -SqlInstance $psitem -TargetLogin $targetowner -ExcludeDatabase $exclude -EnableException:$false).ForEach{
                 It "$($psitem.Database) owner Should Be $targetowner on $($psitem.Server)" {
@@ -80,7 +80,7 @@ Describe "Valid Database Owner" -Tags ValidDatabaseOwner, $filename {
 Describe "Invalid Database Owner" -Tags InvalidDatabaseOwner, $filename {
     $targetowner = Get-DbcConfigValue policy.invaliddbowner.name
     $exclude = Get-DbcConfigValue policy.invaliddbowner.excludedb 
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Database Owners on $psitem" {
             @(Test-DbaDatabaseOwner -SqlInstance $psitem -TargetLogin $targetowner -ExcludeDatabase $exclude -EnableException:$false).ForEach{
                 It "$($psitem.Database) owner should Not be $targetowner on $($psitem.Server)" {
@@ -95,7 +95,7 @@ Describe "Last Good DBCC CHECKDB" -Tags LastGoodCheckDb, $filename {
     $maxdays = Get-DbcConfigValue policy.dbcc.maxdays
     $datapurity = Get-DbcConfigValue skip.dbcc.datapuritycheck
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod    
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Last Good DBCC CHECKDB on $psitem" {
             @(Get-DbaLastGoodCheckDb -SqlInstance $psitem -Database (Get-DbaDatabase -SqlInstance $psitem | Where-Object {$_.CreateDate -lt (Get-Date).AddHours( - $graceperiod)}).name).ForEach{
                 if ($psitem.Database -ne 'tempdb') {
@@ -114,7 +114,7 @@ Describe "Last Good DBCC CHECKDB" -Tags LastGoodCheckDb, $filename {
 
 Describe "Column Identity Usage" -Tags IdentityUsage, $filename {
     $maxpercentage = Get-DbcConfigValue policy.identity.usagepercent
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Column Identity Usage on $psitem" {
             @(Test-DbaIdentityUsage -SqlInstance $psitem).ForEach{
                 if ($psitem.Database -ne 'tempdb') {
@@ -129,7 +129,7 @@ Describe "Column Identity Usage" -Tags IdentityUsage, $filename {
 }
 
 Describe "Recovery Model" -Tags RecoveryModel, DISA, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Recovery Model on $psitem" {
             $exclude = Get-DbcConfigValue policy.recoverymodel.excludedb
             @(Get-DbaDbRecoveryModel -SqlInstance $psitem -ExcludeDatabase $exclude).ForEach{
@@ -142,7 +142,7 @@ Describe "Recovery Model" -Tags RecoveryModel, DISA, $filename {
 }
 
 Describe "Duplicate Index" -Tags DuplicateIndex, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing duplicate indexes on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 $results = Find-DbaDuplicateIndex -SqlInstance $psitem.Parent -Database $psitem.Name
@@ -155,7 +155,7 @@ Describe "Duplicate Index" -Tags DuplicateIndex, $filename {
 }
 
 Describe "Unused Index" -Tags UnusedIndex, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Unused indexes on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 try {
@@ -175,7 +175,7 @@ Describe "Unused Index" -Tags UnusedIndex, $filename {
 }
 
 Describe "Disabled Index" -Tags DisabledIndex, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Disabled indexes on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 $results = Find-DbaDisabledIndex -SqlInstance $psitem.Parent -Database $psitem.Name
@@ -188,7 +188,7 @@ Describe "Disabled Index" -Tags DisabledIndex, $filename {
 }
 
 Describe "Database Growth Event" -Tags DatabaseGrowthEvent, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing database growth event on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 $results = Find-DbaDbGrowthEvent -SqlInstance $psitem.Parent -Database $psitem.Name
@@ -202,7 +202,7 @@ Describe "Database Growth Event" -Tags DatabaseGrowthEvent, $filename {
 
 Describe "Page Verify" -Tags PageVerify, $filename {
     $pageverify = Get-DbcConfigValue policy.pageverify
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing page verify on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 It "$psitem on $($psitem.SqlInstance) should have page verify set to $pageverify" {
@@ -215,7 +215,7 @@ Describe "Page Verify" -Tags PageVerify, $filename {
 
 Describe "Auto Close" -Tags AutoClose, $filename {
     $autoclose = Get-DbcConfigValue policy.database.autoclose
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Auto Close on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 It "$psitem on $($psitem.SqlInstance) should have Auto Close set to $autoclose" {
@@ -228,7 +228,7 @@ Describe "Auto Close" -Tags AutoClose, $filename {
 
 Describe "Auto Shrink" -Tags AutoShrink, $filename {
     $autoshrink = Get-DbcConfigValue policy.database.autoshrink
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Auto Shrink on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 It "$psitem on $($psitem.SqlInstance) should have Auto Shrink set to $autoshrink" {
@@ -242,7 +242,7 @@ Describe "Auto Shrink" -Tags AutoShrink, $filename {
 Describe "Last Full Backup Times" -Tags LastFullBackup, LastBackup, Backup, DISA, $filename {
     $maxfull = Get-DbcConfigValue policy.backup.fullmaxdays
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing last full backups on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem -ExcludeDatabase tempdb | Where-Object {$_.CreateDate -lt (Get-Date).AddHours( - $graceperiod)}).ForEach{
                 $offline = ($psitem.Status -match "Offline")
@@ -257,7 +257,7 @@ Describe "Last Full Backup Times" -Tags LastFullBackup, LastBackup, Backup, DISA
 Describe "Last Diff Backup Times" -Tags LastDiffBackup, LastBackup, Backup, DISA, $filename {
     $maxdiff = Get-DbcConfigValue policy.backup.diffmaxhours
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing last diff backups on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem | Where-Object { (-not $psitem.IsSystemObject) -and $_.CreateDate -lt (Get-Date).AddHours( - $graceperiod) }).ForEach{
                 $offline = ($psitem.Status -match "Offline")
@@ -272,7 +272,7 @@ Describe "Last Diff Backup Times" -Tags LastDiffBackup, LastBackup, Backup, DISA
 Describe "Last Log Backup Times" -Tags LastLogBackup, LastBackup, Backup, DISA, $filename {
     $maxlog = Get-DbcConfigValue policy.backup.logmaxminutes
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing last log backups on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem | Where-Object { -not $psitem.IsSystemObject -and $_.CreateDate -lt (Get-Date).AddHours( - $graceperiod) }).ForEach{
                 if ($psitem.RecoveryModel -ne 'Simple') {
@@ -289,7 +289,7 @@ Describe "Last Log Backup Times" -Tags LastLogBackup, LastBackup, Backup, DISA, 
 
 Describe "Virtual Log Files" -Tags VirtualLogFile, $filename {
     $vlfmax = Get-DbcConfigValue policy.database.maxvlf
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Database VLFs on $psitem" {
             @(Test-DbaVirtualLogFile -SqlInstance $psitem).ForEach{
                 It "$($psitem.Database) VLF count on $($psitem.SqlInstance) Should Be less than $vlfmax" {
@@ -304,7 +304,7 @@ Describe "Log File Count Checks" -Tags LogfileCount, $filename {
     $LogFileCountTest = Get-DbcConfigValue skip.database.logfilecounttest
     $LogFileCount = Get-DbcConfigValue policy.database.logfilecount
     If (-not $LogFileCountTest) {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing Log File count and size for $psitem" {
                 (Get-DbaDatabase -SqlInstance $psitem | Select-Object SqlInstance, Name).ForEach{
                     $Files = Get-DbaDatabaseFile -SqlInstance $psitem.SqlInstance -Database $psitem.Name
@@ -321,7 +321,7 @@ Describe "Log File Count Checks" -Tags LogfileCount, $filename {
 Describe "Log File Size Checks" -Tags LogfileSize, $filename {
     $LogFileSizePercentage = Get-DbcConfigValue policy.database.logfilesizepercentage
     $LogFileSizeComparison = Get-DbcConfigValue policy.database.logfilesizecomparison
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Log File count and size for $psitem" {
             (Get-DbaDatabase -SqlInstance $psitem | Select-Object SqlInstance, Name).ForEach{
                 $Files = Get-DbaDatabaseFile -SqlInstance $psitem.SqlInstance -Database $psitem.Name
@@ -342,7 +342,7 @@ Describe "Log File Size Checks" -Tags LogfileSize, $filename {
 Describe "Correctly sized Filegroup members" -Tags FileGroupBalanced, $filename {
     $Tolerance = Get-DbcConfigValue policy.database.filebalancetolerance
 
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing for balanced FileGroups on $psitem" {
             (Get-DbaDatabase -SqlInstance $psitem | Select-Object SqlInstance, Name).ForEach{
                 $Files = Get-DbaDatabaseFile -SqlInstance $psitem.SqlInstance -Database $psitem.Name
@@ -363,7 +363,7 @@ Describe "Correctly sized Filegroup members" -Tags FileGroupBalanced, $filename 
 
 Describe "Auto Create Statistics" -Tags AutoCreateStatistics, $filename {
     $autocreatestatistics = Get-DbcConfigValue policy.database.autocreatestatistics
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Auto Create Statistics on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 It "$psitem on $($psitem.SqlInstance) should have Auto Create Statistics set to $autocreatestatistics" {
@@ -376,7 +376,7 @@ Describe "Auto Create Statistics" -Tags AutoCreateStatistics, $filename {
 
 Describe "Auto Update Statistics" -Tags AutoUpdateStatistics, $filename {
     $autoupdatestatistics = Get-DbcConfigValue policy.database.autoupdatestatistics
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Auto Update Statistics on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 It "$psitem on $($psitem.SqlInstance) should have Auto Update Statistics set to $autoupdatestatistics" {
@@ -389,7 +389,7 @@ Describe "Auto Update Statistics" -Tags AutoUpdateStatistics, $filename {
 
 Describe "Auto Update Statistics Asynchronously" -Tags AutoUpdateStatisticsAsynchronously, $filename {
     $autoupdatestatisticsasynchronously = Get-DbcConfigValue policy.database.autoupdatestatisticsasynchronously
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Auto Update Statistics Asynchronously on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem).ForEach{
                 It "$psitem on $($psitem.SqlInstance) should have Auto Update Statistics Asynchronously set to $autoupdatestatisticsasynchronously" {
@@ -404,7 +404,7 @@ Describe "Datafile Auto Growth Configuration" -Tags DatafileAutoGrowthType, $fil
     $datafilegrowthtype = Get-DbcConfigValue policy.database.filegrowthtype 
     $datafilegrowthvalue = Get-DbcConfigValue policy.database.filegrowthvalue 
     $exclude = Get-DbcConfigValue policy.database.filegrowthexcludedb
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing datafile growth type on $psitem" {
             (Get-DbaDatabaseFile -SqlInstance $psitem -ExcludeDatabase $exclude ).ForEach{
                 if (-Not (($psitem.Growth -eq 0) -and (Get-DbcConfigValue skip.database.filegrowthdisabled))) {
@@ -428,7 +428,7 @@ Describe "Datafile Auto Growth Configuration" -Tags DatafileAutoGrowthType, $fil
 }
 
 Describe "Trustworthy Option" -Tags Trustworthy, DISA, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing database trustworthy option on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem -ExcludeDatabase msdb).ForEach{
                 It "Trustworthy is set to false on $($psitem.Name)" {
@@ -440,7 +440,7 @@ Describe "Trustworthy Option" -Tags Trustworthy, DISA, $filename {
 }
 
 Describe "Database Orphaned User" -Tags OrphanedUser, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing database orphaned user event on $psitem" {
             $results = Get-DbaOrphanUser -SqlInstance $psitem
             It "$psitem should return 0 orphaned users" {
@@ -451,7 +451,7 @@ Describe "Database Orphaned User" -Tags OrphanedUser, $filename {
 }
 
 Describe "PseudoSimple Recovery Model" -Tags PseudoSimple, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing database is not in PseudoSimple recovery model on $psitem" {
             @(Get-DbaDatabase -SqlInstance $PSItem -ExcludeDatabase tempdb).ForEach{
                 It "$($psitem.Name) has PseudoSimple recovery model equal false on $($psitem.Parent)" {

--- a/checks/Domain.Tests.ps1
+++ b/checks/Domain.Tests.ps1
@@ -2,7 +2,7 @@ $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 
 Describe "Active Directory Domain Name" -Tags DomainName, $filename {
     $domain = Get-DbcConfigValue -Name domain.name
-    (Get-ComputerName).ForEach{
+    @(Get-ComputerName).ForEach{
         Context "Testing Active Directory Domain Name on $psitem" {
             It "$psitem Should Be on the Domain $domain" {
                 (Get-DbaCmObject -Class Win32_ComputerSystem -ComputerName $psitem -Credential $credential).Domain | Should -Be $domain -Because 'The machine needs to be on the domain'
@@ -14,7 +14,7 @@ Describe "Active Directory Domain Name" -Tags DomainName, $filename {
 # Skipping this for now until we get AdsiPS command equiv
 Describe "Active Directory OU" -Tags OrganizationalUnit, $filename {
     $dc = Get-DbcConfigValue -Name domain.domaincontroller
-    (Get-ComputerName).ForEach{
+    @(Get-ComputerName).ForEach{
         Context "Testing Active Directory OU on $psitem" {
             if (-not $value) {
                 # Can be passed by Invoke-DbcCheck -Value

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -1,7 +1,7 @@
 $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 
 Describe "SQL Engine Service" -Tags SqlEngineServiceAccount, ServiceAccount, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing SQL Engine Service on $psitem" {
             @(Get-DbaSqlService -ComputerName $psitem -Type Engine).ForEach{
                 It "SQL Engine service account Should Be running on $($psitem.InstanceName)" {
@@ -16,7 +16,7 @@ Describe "SQL Engine Service" -Tags SqlEngineServiceAccount, ServiceAccount, $fi
 }
 
 Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $filename {
-    (Get-ComputerName).ForEach{
+    @(Get-ComputerName).ForEach{
         Context "Testing SQL Browser Service on $psitem" {
             if (@(Get-DbaSqlService -ComputerName $psitem -Type Engine).Count -eq 1) {
                 It "SQL browser service on $psitem Should Be Stopped as only one instance is installed" {
@@ -43,7 +43,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 }
 
     Describe "TempDB Configuration" -Tags TempDbConfiguration, $filename {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing TempDB Configuration on $psitem" {
                 $TempDBTest = Test-DbaTempDbConfiguration -SqlServer $psitem
                 It "should have TF1118 enabled on $($TempDBTest[0].SqlInstance)" -Skip:(Get-DbcConfigValue -Name skip.TempDb1118) {
@@ -66,7 +66,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
     }
 
     Describe "Ad Hoc Workload Optimization" -Tags AdHocWorkload, $filename {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing Ad Hoc Workload Optimization on $psitem" {
                 It "$psitem Should Be Optimised for Ad Hoc workloads" {
                     @(Test-DbaOptimizeForAdHoc -SqlInstance $psitem).ForEach{
@@ -78,7 +78,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
     }
 
     Describe "Backup Path Access" -Tags BackupPathAccess, Storage, DISA, $filename {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing Backup Path Access on $psitem" {
                 if (-not (Get-DbcConfigValue policy.storage.backuppath)) {
                     $backuppath = (Get-DbaDefaultPath -SqlInstance $psitem).Backup
@@ -96,7 +96,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "Dedicated Administrator Connection" -Tags DAC, $filename {
         $dac = Get-DbcConfigValue policy.dacallowed
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing Dedicated Administrator Connection on $psitem" {
                 It "DAC is set to $dac on $psitem" {
                     (Get-DbaSpConfigure -SqlInstance $psitem -ConfigName 'RemoteDACConnectionsEnabled').ConfiguredValue -eq 1 | Should -Be $dac -Because 'This is the setting that you have chosen for DAC connections'
@@ -107,7 +107,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "Network Latency" -Tags NetworkLatency, Connectivity, $filename {
         $max = Get-DbcConfigValue policy.network.latencymaxms
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing Network Latency on $psitem" {
                 @(Test-DbaNetworkLatency -SqlInstance $psitem).ForEach{
                     It "network latency Should Be less than $max ms on $($psitem.InstanceName)" {
@@ -119,7 +119,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
     }
 
     Describe "Linked Servers" -Tags LinkedServerConnection, Connectivity, $filename {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing Linked Servers on $psitem" {
                 @(Test-DbaLinkedServerConnection -SqlInstance $psitem).ForEach{
                     It "Linked Server $($psitem.LinkedServerName) on on $($psitem.SqlInstance) has connectivity" {
@@ -131,7 +131,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
     }
 
     Describe "Max Memory" -Tags MaxMemory, $filename {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing Max Memory on $psitem" {
                 It "Max Memory setting Should Be correct on $psitem" {
                     @(Test-DbaMaxMemory -SqlInstance $psitem).ForEach{
@@ -143,7 +143,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
     }
 
     Describe "Orphaned Files" -Tags OrphanedFile, $filename {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Checking for orphaned database files on $psitem" {
                 It "$psitem doesn't have orphan files" {
                     (Find-DbaOrphanedFile -SqlInstance $psitem).Count | Should -Be 0 -Because 'You dont want any orphaned files - Use Find-DbaOrphanedFiles to locate them'
@@ -153,7 +153,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
     }
 
     Describe "SQL + Windows names match" -Tags ServerNameMatch, $filename {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing instance name matches Windows name for $psitem" {
                 It "$psitem doesn't require rename" {
                     (Test-DbaServerName -SqlInstance $psitem).RenameRequired | Should -BeFalse -Because 'SQL and Windows should agree on the server name'
@@ -164,7 +164,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "SQL Memory Dumps" -Tags MemoryDump, $filename {
         $maxdumps = Get-DbcConfigValue -Name policy.dump.maxcount
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Checking that dumps on $psitem do not exceed $maxdumps for $psitem" {
                 $count = (Get-DbaDump -SqlInstance $psitem).Count
                 It "dump count of $count is less than or equal to the $maxdumps dumps on $psitem" {
@@ -176,7 +176,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "Supported Build" -Tags SupportedBuild, DISA, $filename {
         $BuildWarning = Get-DbcConfigValue -Name  policy.build.warningwindow
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Checking that build is still supportedby Microsoft for $psitem" {
                 $results = Get-DbaSqlBuildReference -SqlInstance $psitem
                 It "$($results.Build) on $psitem is still supported" {
@@ -190,7 +190,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
     }
 
     Describe "SA Login Renamed" -Tags SaRenamed, DISA, $filename {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Checking that sa login has been renamed on $psitem" {
                 $results = Get-DbaLogin -SqlInstance $psitem -Login sa
                 It "sa login does not exist on $psitem" {
@@ -202,7 +202,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "Default Backup Compression" -Tags DefaultBackupCompression, $filename {
         $defaultbackupcompression = Get-DbcConfigValue policy.backup.defaultbackupcompression
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing Default Backup Compression on $psitem" {
                 It "Default Backup Compression is set to $defaultbackupcompression on $psitem" {
                     (Get-DbaSpConfigure -SqlInstance $psitem -ConfigName 'DefaultBackupCompression').ConfiguredValue -eq 1 | Should -Be $defaultbackupcompression -Because 'The default backup compression should be set correctly'
@@ -213,7 +213,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "Stopped XE Sessions" -Tags XESessionStopped, ExtendedEvent, $filename {
         $xesession = Get-DbcConfigValue policy.xevent.requiredstoppedsession
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Checking sessions on $psitem" {
                 @(Get-DbaXESession -SqlInstance $psitem).ForEach{
                     if ($psitem.Name -in $xesession) {
@@ -228,7 +228,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "Running XE Sessions" -Tags XESessionRunning, ExtendedEvent, $filename {
         $xesession = Get-DbcConfigValue policy.xevent.requiredrunningsession
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Checking running sessions on $psitem" {
                 @(Get-DbaXESession -SqlInstance $psitem).ForEach{
                     if ($psitem.Name -in $xesession) {
@@ -243,7 +243,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "XE Sessions Running Allowed" -Tags XESessionRunningAllowed, ExtendedEvent, $filename {
         $xesession = Get-DbcConfigValue policy.xevent.validrunningsession
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Checking sessions on $psitem" {
                 @(Get-DbaXESession -SqlInstance $psitem).ForEach{
                     if ($psitem.Name -notin $xesession) {
@@ -258,7 +258,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "OLE Automation" -Tags OLEAutomation, $filename {
         $OLEAutomation = Get-DbcConfigValue policy.oleautomation
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing OLE Automation on $psitem" {
                 It "OLE Automation is set to $OLEAutomation on $psitem" {
                     (Get-DbaSpConfigure -SqlInstance $psitem -ConfigName 'OleAutomationProceduresEnabled').ConfiguredValue -eq 1 | Should -Be $OLEAutomation -Because 'OLE Automation can introduce additional security risks'
@@ -269,7 +269,7 @@ Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $
 
     Describe "sp_whoisactive is Installed" -Tags WhoIsActiveInstalled, $filename {
         $db = Get-DbcConfigValue policy.whoisactive.database
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             Context "Testing WhoIsActive exists on $psitem" {
                 It "WhoIsActive should exists on $db on $psitem" {
                     (Get-DbaSqlModule -SqlInstance $psitem -Database $db -Type StoredProcedure | Where-Object name -eq "sp_WhoIsActive") | Should -Not -Be $Null -Because 'The sp_WhoIsActive stored procedure should be installed'

--- a/checks/LogShipping.Tests.ps1
+++ b/checks/LogShipping.Tests.ps1
@@ -1,6 +1,6 @@
 $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Describe "Log Shipping Status Primary" -Tags LogShippingPrimary, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing the primary databases on $psitem" {
             @(Test-DbaLogShippingStatus -SqlInstance $psitem -Primary).ForEach{
                 It "Status Should Be OK for $($psitem.Database) on $($psitem.SqlInstance)" {
@@ -11,7 +11,7 @@ Describe "Log Shipping Status Primary" -Tags LogShippingPrimary, $filename {
     }
 }
 Describe "Log Shipping Status Secondary" -Tags LogShippingSecondary, $filename {
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing the secondary databases on $psitem" {
             @(Test-DbaLogShippingStatus -SqlInstance $psitem -Secondary).ForEach{
                 It "Status Should Be OK for $($psitem.Database) on $($psitem.SqlInstance)" {

--- a/checks/MaintenanceSolution.Tests.ps1
+++ b/checks/MaintenanceSolution.Tests.ps1
@@ -3,7 +3,7 @@ $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Describe "Ola maintenance solution installed" -Tags OlaInstalled, $filename{
     $OlaSPs = @('CommandExecute', 'DatabaseBackup', 'DatabaseIntegrityCheck', 'IndexOptimize')
     $oladb = Get-DbcConfigValue policy.ola.database
-    (Get-SqlInstance).ForEach{        
+    @(Get-SqlInstance).ForEach{        
         $db = Get-DbaDatabase -SqlInstance $PSItem -Database $oladb
         Context "Checking the CommandLog table on $psitem"{            
             It "The CommandLog table exists in $oladb on $PSItem" {
@@ -42,7 +42,7 @@ $jobnames | ForEach-Object {
     #Write-PSFMessage -Level Host -Message "$jobname / $JobPrefix / $tagname"
 
     Describe "Ola - $Jobname" -tags $tagname, OlaJobs, $filename {
-        (Get-SqlInstance).ForEach{
+        @(Get-SqlInstance).ForEach{
             $job = Get-DbaAgentJob -SqlInstance $PSItem -Job $JobName
             Context  "Is job enabled on $PSItem" {
                 It "$JobName Should Be enabled - $Enabled " {

--- a/checks/Server.Tests.ps1
+++ b/checks/Server.Tests.ps1
@@ -1,7 +1,7 @@
 $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 
 Describe "Server Power Plan Configuration" -Tags PowerPlan, $filename {
-    (Get-ComputerName).ForEach{
+    @(Get-ComputerName).ForEach{
         Context "Testing Server Power Plan Configuration on $psitem" {
             It "PowerPlan is High Performance on $psitem" {
                 (Test-DbaPowerPlan -ComputerName $psitem).IsBestPractice | Should -BeTrue
@@ -34,7 +34,7 @@ Describe "Instance Connection" -Tags InstanceConnection, Connectivity, $filename
 }
 
 Describe "SPNs" -Tags SPN, $filename {
-    (Get-ComputerName).ForEach{
+    @(Get-ComputerName).ForEach{
         Context "Testing SPNs on $psitem" {
             $computer = $psitem
             @(Test-DbaSpn -ComputerName $psitem).ForEach{
@@ -48,7 +48,7 @@ Describe "SPNs" -Tags SPN, $filename {
 
 Describe "Disk Space" -Tags DiskCapacity, Storage, DISA, $filename {
     $free = Get-DbcConfigValue policy.diskspace.percentfree
-    (Get-ComputerName).ForEach{
+    @(Get-ComputerName).ForEach{
         Context "Testing Disk Space on $psitem" {
             @(Get-DbaDiskSpace -ComputerName $psitem).ForEach{
                 It "$($psitem.Name) with $($psitem.PercentFree)% free should be at least $free% free on $($psitem.ComputerName)" {
@@ -63,7 +63,7 @@ Describe "Ping Computer" -Tags PingComputer, $filename {
     $pingmsmax = Get-DbcConfigValue policy.connection.pingmaxms 
     $pingcount = Get-DbcConfigValue policy.connection.pingcount 
     $skipping = Get-DbcConfigValue skip.connection.ping
-    (Get-ComputerName).ForEach{
+    @(Get-ComputerName).ForEach{
         Context "Testing Ping to  $psitem" {
             $results = Test-Connection -Count $pingcount -ComputerName $psitem -ErrorAction SilentlyContinue | Select-Object -ExpandProperty ResponseTime
             $avgResponseTime = (($results | Measure-Object -Average).Average) / $pingcount

--- a/checks/Server.Tests.ps1
+++ b/checks/Server.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Instance Connection" -Tags InstanceConnection, Connectivity, $filename
     $skipremote = Get-DbcConfigValue skip.connection.remoting
     $skipping = Get-DbcConfigValue skip.connection.ping
     $authscheme = Get-DbcConfigValue policy.connection.authscheme 
-    (Get-SqlInstance).ForEach{
+    @(Get-SqlInstance).ForEach{
         Context "Testing Instance Connection on $psitem" {
             $connection = Test-DbaConnection -SqlInstance $psitem
             It "connects successfully to $psitem" {


### PR DESCRIPTION
I've add @ before all (Get-SqlInstance).ForEach
It resolves #340, #327 