### PR TITLE
Clear out mail folder if already exists

### DIFF
--- a/functions/Send-DbcMailMessage.ps1
+++ b/functions/Send-DbcMailMessage.ps1
@@ -137,6 +137,7 @@
                 $null = New-Item -ItemType Directory -Path "$script:maildirectory\notify" -ErrorAction Stop
             }
             if (-not (Test-Path -Path $xmlfile)) {
+	         Get-ChildItem -Path "$script:maildirectory\*.*" | Remove-Item -ErrorAction SilentlyContinue
                 Export-Clixml -Path $xmlfile -InputObject $null
             }
         }


### PR DESCRIPTION
I'm finding a lot of test runs of this job are filling the mail folder with files and subsequent runs take an extremely long time to try to parse through them all. Better to be proactive and clear the folder in the event a previous command failed/was stopped and left orphan files.