### PR TITLE
351 Database Collation test

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -1,17 +1,17 @@
 $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 
 Describe "Database Collation" -Tags DatabaseCollation, $filename {
-    $exclude = Get-DbcConfigValue policy.database.collationexludedb
-    $excludeall = "ReportingServer", "ReportingServerTempDB"
-    $excludeall += $exclude
+    $Wrongcollation = Get-DbcConfigValue policy.database.wrongcollation
+    $exclude = "ReportingServer", "ReportingServerTempDB"
+    $exclude += $Wrongcollation
     @(Get-SqlInstance).ForEach{
         Context "Testing database collation on $psitem" {
-            @(Test-DbaDatabaseCollation -SqlInstance $psitem -ExcludeDatabase $excludeall ).ForEach{
+            @(Test-DbaDatabaseCollation -SqlInstance $psitem -ExcludeDatabase $exclude ).ForEach{
                 It "database collation ($($psitem.DatabaseCollation)) should match server collation ($($psitem.ServerCollation)) for $($psitem.Database) on $($psitem.SqlInstance)" {
                     $psitem.ServerCollation | Should -Be $psitem.DatabaseCollation -Because "You will get collation conflict errors in tempdb"
                 }
             }
-            @(Test-DbaDatabaseCollation -SqlInstance $psitem -Database $excludeall ).ForEach{
+            @(Test-DbaDatabaseCollation -SqlInstance $psitem -Database $Wrongcollation ).ForEach{
                 It "database collation ($($psitem.DatabaseCollation)) should not match server collation ($($psitem.ServerCollation)) for $($psitem.Database) on $($psitem.SqlInstance)" {
                     $psitem.ServerCollation | Should -Not -Be $psitem.DatabaseCollation -Because "You have defined the database to have another collation then the server. You will get collation conflict errors in tempdb"
                 }

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -2,7 +2,7 @@
 #Set-PSFConfig -Handler { if (Get-PSFTaskEngineCache -Module dbachecks -Name module-imported) { Write-PSFMessage -Level Warning -Message "This setting will only take effect on the next console start" } }
 
 #Add some validation for values with limited options
-$LogFileComparisonValidationssb = { param ([string]$input) if ($input -in ('average', 'maximum')) { [PsCustomObject]@{Success = $true; value = $input} } else { [PsCustomObject]@{Success = $false; message = "must be average or maximum - $input"} 
+$LogFileComparisonValidationssb = { param ([string]$input) if ($input -in ('average', 'maximum')) { [PsCustomObject]@{Success = $true; value = $input} } else { [PsCustomObject]@{Success = $false; message = "must be average or maximum - $input"}
     } }
 Register-PSFConfigValidation -Name validation.LogFileComparisonValidations -ScriptBlock $LogFileComparisonValidationssb
 $EmailValidationSb = {
@@ -102,7 +102,7 @@ Set-PSFConfig -Module dbachecks -Name policy.database.logfilesizepercentage -Val
 Set-PSFConfig -Module dbachecks -Name policy.database.logfilesizecomparison -Validation validation.logfilecomparisonvalidations -Value 'average' -Initialize -Description "How to compare data and log file size, options are maximum or average"
 Set-PSFConfig -Module dbachecks -Name policy.database.filebalancetolerance -Value 5 -Initialize -Description "Percentage for Tolerance for checking for balanced files in a filegroups"
 Set-PSFConfig -Module dbachecks -Name policy.database.filegrowthfreespacethreshold -Value 20 -Initialize -Description "Integer representing percentage of free space within a database file before warning"
-Set-PSFConfig -Module dbachecks -Name policy.database.collationexludedb -Value @() -Initialize -Description "Databases to exclude from collation check"
+Set-PSFConfig -Module dbachecks -Name policy.database.wrongcollation -Value @() -Initialize -Description "Databases that doesnt match server collation check"
 
 # Policy for Ola Hallengren Maintenance Solution
 Set-PSFConfig -Module dbachecks -name policy.ola.installed -Validation bool -Value $true -Initialize -Description "Checks to see if Ola Hallengren solution is installed"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -2,17 +2,17 @@
 #Set-PSFConfig -Handler { if (Get-PSFTaskEngineCache -Module dbachecks -Name module-imported) { Write-PSFMessage -Level Warning -Message "This setting will only take effect on the next console start" } }
 
 #Add some validation for values with limited options
-$LogFileComparisonValidationssb = { param ([string]$input) if ($input -in ('average','maximum')){ [PsCustomObject]@{Success = $true; value = $input} } else { [PsCustomObject]@{Success = $false; message = "must be average or maximum - $input"} } }
+$LogFileComparisonValidationssb = { param ([string]$input) if ($input -in ('average', 'maximum')) { [PsCustomObject]@{Success = $true; value = $input} } else { [PsCustomObject]@{Success = $false; message = "must be average or maximum - $input"} 
+    } }
 Register-PSFConfigValidation -Name validation.LogFileComparisonValidations -ScriptBlock $LogFileComparisonValidationssb
-$EmailValidationSb = { 
-    param ([string]$input) 
+$EmailValidationSb = {
+    param ([string]$input)
     $EmailRegEx = "^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$"
-    if ($input -match $EmailRegEx){ 
-        [PsCustomObject]@{Success = $true; value = $input} 
-    } 
-    else { 
-        [PsCustomObject]@{Success = $false; message = "does not appear to be an email address - $input"} 
-    } 
+    if ($input -match $EmailRegEx) {
+        [PsCustomObject]@{Success = $true; value = $input}
+    } else {
+        [PsCustomObject]@{Success = $false; message = "does not appear to be an email address - $input"}
+    }
 }
 Register-PSFConfigValidation -Name validation.EmailValidation -ScriptBlock $EmailValidationSb
 
@@ -59,7 +59,7 @@ Set-PSFConfig -Module dbachecks -Name policy.network.latencymaxms -Value 40 -Ini
 
 #Recovery Model
 Set-PSFConfig -Module dbachecks -Name policy.recoverymodel.type -Value "Full" -Initialize -Description "Standard recovery model"
-Set-PSFConfig -Module dbachecks -Name policy.recoverymodel.excludedb -Value @('master','tempdb') -Initialize -Description "Databases to exclude from standard recovery model check"
+Set-PSFConfig -Module dbachecks -Name policy.recoverymodel.excludedb -Value @('master', 'tempdb') -Initialize -Description "Databases to exclude from standard recovery model check"
 
 #DBOwners
 Set-PSFConfig -Module dbachecks -Name policy.validdbowner.name -Value "sa" -Initialize -Description "The database owner account should be this user"
@@ -102,6 +102,7 @@ Set-PSFConfig -Module dbachecks -Name policy.database.logfilesizepercentage -Val
 Set-PSFConfig -Module dbachecks -Name policy.database.logfilesizecomparison -Validation validation.logfilecomparisonvalidations -Value 'average' -Initialize -Description "How to compare data and log file size, options are maximum or average"
 Set-PSFConfig -Module dbachecks -Name policy.database.filebalancetolerance -Value 5 -Initialize -Description "Percentage for Tolerance for checking for balanced files in a filegroups"
 Set-PSFConfig -Module dbachecks -Name policy.database.filegrowthfreespacethreshold -Value 20 -Initialize -Description "Integer representing percentage of free space within a database file before warning"
+Set-PSFConfig -Module dbachecks -Name policy.database.collationexludedb -Value @() -Initialize -Description "Databases to exclude from collation check"
 
 # Policy for Ola Hallengren Maintenance Solution
 Set-PSFConfig -Module dbachecks -name policy.ola.installed -Validation bool -Value $true -Initialize -Description "Checks to see if Ola Hallengren solution is installed"
@@ -144,10 +145,10 @@ Set-PSFConfig -Module dbachecks -Name policy.whoisactive.database -Value "master
 #Build
 Set-PSFConfig -Module dbachecks -Name policy.build.warningwindow -Value 6 -Initialize -Description "The number of months prior to a build being unsupported that you want warning about"
 
-# The frequency of the Ola Hallengrens User Full backups 
-        # See https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.agent.jobschedule.frequencyinterval.aspx
-        # for full options
-        # 1 for Sunday 127 for every day
+# The frequency of the Ola Hallengrens User Full backups
+# See https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.agent.jobschedule.frequencyinterval.aspx
+# for full options
+# 1 for Sunday 127 for every day
 
 # skips - these are for whole checks that should not run by default or internal commands that can't be skipped using ExcludeTag
 Set-PSFConfig -Module dbachecks -Name skip.dbcc.datapuritycheck -Validation bool -Value $false -Initialize -Description "Skip data purity check in last good dbcc command"


### PR DESCRIPTION
 I have changed the Collation test so that you can add databases by name that you want to test against the server collation. The test will now test if the database doesn't have the same collation.

Added config value name in the configuration file.

I'm not sure if it's a good or bad idea to test the given databases that they are the wrong collation. Would like some feedback on that.

Also if there is a better way to add the static db that we have excluded now or if we should move them to the wrongcollation config value?

