### PR TITLE
Database collation issue With test

### DIFF
--- a/dbachecks.psd1
+++ b/dbachecks.psd1
@@ -12,7 +12,7 @@
     
     # Version number of this module.
     
-    ModuleVersion          = '1.1.106'
+    ModuleVersion          = '1.1.107'
     
     # ID used to uniquely identify this module
     GUID                   = '578c5d98-50c8-43a8-bdbb-d7159028d7ac'


### PR DESCRIPTION
If the variable $wrongcollation isn't set the second test needs to be excluded. This is due to that test-dbadatabasecollation then checks all datatabases.

Added an if statement to work around this. After this change it works as I planned it to work.

Test all databases minus reportserver and reportservertempdb + $wrongcollation
If $wrongcollation is empty do not do the second test

The second test I added if to test that they really are wrong collation in the database.