### PR TITLE
Stop-PSFFunction in catch block should use -ErrorRecord

### DIFF
--- a/functions/Import-DbcConfig.ps1
+++ b/functions/Import-DbcConfig.ps1
@@ -45,7 +45,7 @@
             $results = Get-Content -Path $Path | ConvertFrom-Json
         }
         catch {
-            Stop-PSFFunction -Message "Failure" -Exception $_
+            Stop-PSFFunction -Message "Failure" -ErrorRecord $_
             return
         }
         

--- a/functions/Invoke-DbcConfigFile.ps1
+++ b/functions/Invoke-DbcConfigFile.ps1
@@ -36,7 +36,7 @@
             Write-PSFMessage -Level	Output -Message "Remember to run Import-DbcConfig when you've finished your edits"
         }
         catch {
-            Stop-PSFFunction -Message "Failure" -Exception $_
+            Stop-PSFFunction -Message "Failure" -ErrorRecord $_
             return
         }
     }

--- a/functions/Start-DbcPowerBi.ps1
+++ b/functions/Start-DbcPowerBi.ps1
@@ -60,7 +60,7 @@
             Invoke-Item -Path $path
         }
         catch {
-            Stop-PSFFunction -Message "Failure" -Exception $_.Exception
+            Stop-PSFFunction -Message "Failure" -ErrorRecord $_
             return
         }
     }

--- a/functions/Update-DbcPowerBiDataSource.ps1
+++ b/functions/Update-DbcPowerBiDataSource.ps1
@@ -73,7 +73,7 @@
             }
         }
         catch {
-            Stop-PSFFunction -Message "Failure" -Exception $_
+            Stop-PSFFunction -Message "Failure" -ErrorRecord $_
             return
         }
         
@@ -94,7 +94,7 @@
                 Write-PSFMessage -Level Output -Message "Wrote results to $filename"
             }
             catch {
-                Stop-PSFFunction -Message "Failure" -Exception $_
+                Stop-PSFFunction -Message "Failure" -ErrorRecord $_
                 return
             }
         }


### PR DESCRIPTION
use of `Stop-PSFunction` in catch blocks was inconsistent. Sometimes it was correctly passing the exception parameter as `-ErrorRecord`, and sometimes using `-Exception` and causing problems. 

Following @FriedrichWeinmann advice I have changed them all to `-ErrorRecord`. 

This commit resolves #379. 