### PR TITLE
Issue390 database owner config arrays

### DIFF
--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Valid Job Owner" -Tags ValidJobOwner, $filename {
     @(Get-SqlInstance).ForEach{
         Context "Testing job owners on $psitem" {
             @(Get-DbaAgentJob -SqlInstance $psitem -EnableException:$false).ForEach{
-                It "$($psitem.Name) owner $($psitem.OwnerLoginName) should be in this list $targetowner on $($psitem.Server)" {
+                It "Job $($psitem.Name)  - owner $($psitem.OwnerLoginName) should be in this list ( $( [String]::Join(", ", $targetowner) ) ) on $($psitem.SqlInstance)" {
                     $psitem.OwnerLoginName | Should -BeIn $TargetOwner -Because "The account that is the job owner is not what was expected"
                 }
             }

--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -79,7 +79,7 @@ Describe "Valid Database Owner" -Tags ValidDatabaseOwner, $filename {
     @(Get-SqlInstance).ForEach{
         Context "Testing Database Owners on $psitem" {
             @(Get-DbaDatabase -SqlInstance $psitem -ExcludeDatabase $exclude -EnableException:$false).ForEach{
-                It "$($psitem.Name) owner $($psitem.Owner) should be in this list $targetowner on $($psitem.SqlInstance)" {
+                It "Database $($psitem.Name) - owner $($psitem.Owner) should be in this list ( $( [String]::Join(", ", $targetowner) ) ) on $($psitem.SqlInstance)" {
                     $psitem.Owner | Should -BeIn $TargetOwner -Because "The account that is the database owner is not what was expected"
                 }
             }
@@ -88,13 +88,13 @@ Describe "Valid Database Owner" -Tags ValidDatabaseOwner, $filename {
 }
 
 Describe "Invalid Database Owner" -Tags InvalidDatabaseOwner, $filename {
-    $targetowner = Get-DbcConfigValue policy.invaliddbowner.name
-    $exclude = Get-DbcConfigValue policy.invaliddbowner.excludedb
+    [string[]]$targetowner = Get-DbcConfigValue policy.invaliddbowner.name
+    [string[]]$exclude = Get-DbcConfigValue policy.invaliddbowner.excludedb
     @(Get-SqlInstance).ForEach{
         Context "Testing Database Owners on $psitem" {
-            @(Test-DbaDatabaseOwner -SqlInstance $psitem -TargetLogin $targetowner -ExcludeDatabase $exclude -EnableException:$false).ForEach{
-                It "$($psitem.Database) owner should Not be $targetowner on $($psitem.Server)" {
-                    $psitem.CurrentOwner | Should -Not -Be $psitem.TargetOwner -Because "The database owner was one specified as incorrect"
+            @(Get-DbaDatabase -SqlInstance $psitem -ExcludeDatabase $exclude -EnableException:$false).ForEach{
+                It "Database $($psitem.Name) - owner $($psitem.Owner) should Not be in this list ( $( [String]::Join(", ", $targetowner) ) ) on $($psitem.SqlInstance)" {
+                    $psitem.Owner | Should -Not -BeIn $TargetOwner -Because "The database owner was one specified as incorrect"
                 }
             }
         }

--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -74,13 +74,13 @@ Describe "Last Backup VerifyOnly" -Tags TestLastBackupVerifyOnly, Backup, $filen
 }
 
 Describe "Valid Database Owner" -Tags ValidDatabaseOwner, $filename {
-    $targetowner = Get-DbcConfigValue policy.validdbowner.name
-    $exclude = Get-DbcConfigValue policy.validdbowner.excludedb
+    [string[]]$targetowner = Get-DbcConfigValue policy.validdbowner.name
+    [string[]]$exclude = Get-DbcConfigValue policy.validdbowner.excludedb
     @(Get-SqlInstance).ForEach{
         Context "Testing Database Owners on $psitem" {
-            @(Test-DbaDatabaseOwner -SqlInstance $psitem -TargetLogin $targetowner -ExcludeDatabase $exclude -EnableException:$false).ForEach{
-                It "$($psitem.Database) owner Should Be $targetowner on $($psitem.Server)" {
-                    $psitem.CurrentOwner | Should -Be $psitem.TargetOwner -Because "The account that is the database owner is not what was expected"
+            @(Get-DbaDatabase -SqlInstance $psitem -ExcludeDatabase $exclude -EnableException:$false).ForEach{
+                It "$($psitem.Name) owner $($psitem.Owner) should be in this list $targetowner on $($psitem.SqlInstance)" {
+                    $psitem.Owner | Should -BeIn $TargetOwner -Because "The account that is the database owner is not what was expected"
                 }
             }
         }


### PR DESCRIPTION
This allows an array to be specified for the following config values

- policy.validdbowner.name
- policy.validdbowner.excludedb
- policy.invaliddbowner.name
- policy.invaliddbowner.excludedb

In addition the output on the ValidJobOwner test has been changed to match the format on ValidDatabaseOwner.