### PR TITLE
# 236 Added test for missing agent alert for Severity and MessageID

### DIFF
--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -175,6 +175,10 @@ Set-PSFConfig -Module dbachecks -Name agent.dbaoperatoremail -Value $null -Initi
 Set-PSFConfig -Module dbachecks -Name agent.failsafeoperator -Value $null -Initialize -Description "Email address of the DBA Operator in SQL Agent"
 Set-PSFConfig -Module dbachecks -Name agent.databasemailprofile -Value $null -Initialize -Description "Name of the Database Mail Profile in SQL Agent"
 Set-PSFConfig -Module dbachecks -Name agent.validjobowner.name -Value "sa" -Initialize -Description "Agent job owner account should be this user"
+Set-PSFConfig -Module dbachecks -Name agent.alert.messageid -Value @('823', '824', '825') -Initialize -Description "Agent alert messageid to validate; https://www.brentozar.com/blitz/configure-sql-server-alerts/"
+Set-PSFConfig -Module dbachecks -Name agent.alert.Severity -Value @('16', '17', '18', '19', '20', '21', '22', '23', '24', '25') -Initialize -Description "Agent alert severity to validate; https://www.brentozar.com/blitz/configure-sql-server-alerts/"
+Set-PSFConfig -Module dbachecks -Name agent.alert.Job -Value $false -Initialize -Description "Agent alert job notification. Ex job to write to eventlog for SCOM monitoring"
+Set-PSFConfig -Module dbachecks -Name agent.alert.Notification -Value $true -Initialize -Description "Agent alert notification"
 
 # domain
 Set-PSFConfig -Module dbachecks -Name domain.name -Value $null -Initialize -Description "The Active Directory domain that your server is a part of"


### PR DESCRIPTION
Added test for Sql Agent alerts based. It will check both for severity and message id.
Default it will check for severity 16-25 and message id 823,824 and 825
By default it will check that it will send a notification to an operator but can also check if you have a Agent job notification.


PS C:\Github\DbaChecks> invoke-pester .\tests\Unit.Tests.ps1 -Show Summary
Executing all tests in '.\tests\Unit.Tests.ps1'
Tests completed in 11.22s
Tests Passed: 684, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0


