### PR TITLE
New test for adlogins #238

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -296,7 +296,7 @@ Describe "Model Database Growth" -Tags ModelDbGrowth, $filename {
 Describe "Ad Users and Groups " -Tags ADLogin, User, Login, $filename {
     $userexclude = Get-DbcConfigValue policy.adloginuser.excludecheck
     $groupexclude = Get-DbcConfigValue policy.adlogingroup.excludecheck
-    @(Get-SqlInstance).ForEach{
+    @(Get-Instance).ForEach{
         Context "Testing active Directory users on $psitem" {
             @(Test-DbaValidLogin -SqlInstance $psitem -FilterBy LoginsOnly -ExcludeLogin $userexclude).ForEach{
                 It "Active Directory user $($psitem.login) was found in $($psitem.domain)" {

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -293,29 +293,27 @@ Describe "Model Database Growth" -Tags ModelDbGrowth, $filename {
     }
 }
 
-Describe "Ad Users and Groups " -Tags ADLogin, $filename {
+Describe "Ad Users and Groups " -Tags ADLogin, User, Login, $filename {
     $userexclude = Get-DbcConfigValue policy.adloginuser.excludecheck
     $groupexclude = Get-DbcConfigValue policy.adlogingroup.excludecheck
     @(Get-SqlInstance).ForEach{
         Context "Testing active Directory users on $psitem" {
-            
             @(Test-DbaValidLogin -SqlInstance $psitem -FilterBy LoginsOnly -ExcludeLogin $userexclude).ForEach{
-                #write-host $psitem
                 It "Active Directory user $($psitem.login) was found in $($psitem.domain)" {
-                    $psitem.found | Should -Be $true -Because 'SQL Login should be in Active Directory'
+                    $psitem.found | Should -Be $true -Because "$($psitem.login) should be in Active Directory"
                 }
                 if ($psitem.found -eq $true) {
                     It "Active Directory user $($psitem.login) should not have expired password in $($psitem.domain)" {
-                        $psitem.PasswordExpired | Should -Be $false -Because 'Active Directory user password should not be expired.'
+                        $psitem.PasswordExpired | Should -Be $false -Because "$($psitem.login) password should not be expired"
                     }                
                     It "Active Directory user $($psitem.login) should not be lockedout in $($psitem.domain)" {
-                        $psitem.lockedout | Should -Be $false -Because 'Active Directory user should mot be locked out.'
+                        $psitem.lockedout | Should -Be $false -Because "$($psitem.login) should mot be locked out"
                     }
                     It "Active Directory user $($psitem.login) should be enabled on $($psitem.domin)" {
-                        $psitem.Enabled | Should -Be $true -Because 'Active Directory user should be enabled.'
+                        $psitem.Enabled | Should -Be $true -Because "$($psitem.login) should be enabled"
                     }
                     It "Active Directory user $($psitem.login) should not be disabled in SQL Server on $($psitem.Server)" {
-                        $psitem.DisabledInSQLServer | Should -Be $false -Because 'SQL login should be active on the SQL server'
+                        $psitem.DisabledInSQLServer | Should -Be $false -Because "$($psitem.login) should be active on the SQL server"
                     }
                 }
 
@@ -323,15 +321,13 @@ Describe "Ad Users and Groups " -Tags ADLogin, $filename {
         }
 
         Context "Testing active Directory groups on $psitem" {
-            # add so that you can exclude logins from the test
             @(Test-DbaValidLogin -SqlInstance $psitem -FilterBy GroupsOnly -ExcludeLogin $groupexclude).ForEach{
-                #write-host $psitem
                 It "Active Directory group $($psitem.login) was found in $($psitem.domain)" {
-                    $psitem.found | Should -Be $true -Because 'SQL Login should be in Active Directory'
+                    $psitem.found | Should -Be $true -Because "$($psitem.login) should be in Active Directory"
                 }
                 if ($psitem.found -eq $true) {
                     It "Active Directory group $($psitem.login) should not be disabled in SQL Server on $($psitem.Server)" {
-                        $psitem.DisabledInSQLServer | Should -Be $false -Because 'SQL login should be active on the SQL server'
+                        $psitem.DisabledInSQLServer | Should -Be $false -Because "$($psitem.login) should be active on the SQL server"
                     }
                 }
 

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -1,7 +1,7 @@
 $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 
 Describe "SQL Engine Service" -Tags SqlEngineServiceAccount, ServiceAccount, $filename {
-    @(Get-SqlInstance).ForEach{
+    @(Get-Instance).ForEach{
         Context "Testing SQL Engine Service on $psitem" {
             @(Get-DbaSqlService -ComputerName $psitem -Type Engine).ForEach{
                 It "SQL Engine service account Should Be running on $($psitem.InstanceName)" {

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -61,6 +61,10 @@ Set-PSFConfig -Module dbachecks -Name policy.network.latencymaxms -Value 40 -Ini
 Set-PSFConfig -Module dbachecks -Name policy.recoverymodel.type -Value "Full" -Initialize -Description "Standard recovery model"
 Set-PSFConfig -Module dbachecks -Name policy.recoverymodel.excludedb -Value @('master', 'tempdb') -Initialize -Description "Databases to exclude from standard recovery model check"
 
+#Logins
+Set-PSFConfig -Module dbachecks -Name policy.adloginuser.excludecheck -Value "" -Initialize -Description "Active Directory User logins to exclude from test."
+Set-PSFConfig -Module dbachecks -Name policy.adlogingroup.excludecheck -Value "" -Initialize -Description "Active Directory Groups logins to exclude from test."
+
 #DBOwners
 Set-PSFConfig -Module dbachecks -Name policy.validdbowner.name -Value "sa" -Initialize -Description "The database owner account should be this user"
 Set-PSFConfig -Module dbachecks -Name policy.validdbowner.excludedb -Value @('master', 'msdb', 'model', 'tempdb')  -Initialize -Description "Databases to exclude from valid dbowner checks"


### PR DESCRIPTION
Added test for ad users and groups that are removed in the AD but not on the SQL server.

Orphaned users in the database has a test in the database checks.

Right now there can be an error for the group test in the test-dbavalidogin but the fix has been merged in dbatools [PR 3386](https://github.com/sqlcollaborative/dbatools/pull/3386) so should soon be fixed.

The test will check if the SQL login exists in the AD if it does it will do more checks so that it should work properly. It will check for password expired, locked out, enabled and if its enabled on the sql server

The test will also check ad groups if the exists in the AD and if the do check if they are enabled on the SQL server

Not sure if this covers what was asked for in Issue #238