### PR TITLE
a script that helps with testing checks in VS Code

### DIFF
--- a/internal/scripts/workinprogress.ps1
+++ b/internal/scripts/workinprogress.ps1
@@ -1,0 +1,32 @@
+param([string]$workspace, [string]$fullPath, [string]$file, [int]$line)
+
+Remove-Module dbachecks
+Import-Module $workspace -Force 
+
+if ($file -like "*.Tests.ps1") {
+    # if it is a pester file try to get the 'current' tag
+    $code = [Management.Automation.Language.Parser]::ParseInput((Get-Content $fullPath -Raw), [ref]$null, [ref]$null)
+
+    $firstTag = $null 
+
+    $code.FindAll([Func[Management.Automation.Language.Ast, bool]] {
+        param($ast) 
+        $ast.Extent.StartLineNumber -le $line -and 
+        $ast.Extent.EndLineNumber -ge $line -and
+        $ast.CommandElements -and 
+        $ast.CommandElements[0].Value -eq "describe"
+    }, $true) | ForEach-Object {
+        $ce = $psitem.CommandElements
+        $tagsIndex = $ce.IndexOf(($ce | Where-Object ParameterName -eq "Tags")) + 1
+        $tags = if ($tagsIndex -and $tagsIndex -lt $ce.Count) { $ce[$tagsIndex].Extent }
+
+        if ($tags) {
+            $firstTag = $tags.Text.Split(',')[0].Trim()
+        }
+    }
+
+    # if first tag has been found execute the test only for that tag 
+    if ($firstTag) {
+        Invoke-DbcCheck -Script $fullPath -Tag $firstTag
+    }
+}

--- a/internal/scripts/workinprogress.ps1
+++ b/internal/scripts/workinprogress.ps1
@@ -1,6 +1,5 @@
 param([string]$workspace, [string]$fullPath, [string]$file, [int]$line)
 
-Remove-Module dbachecks
 Import-Module $workspace -Force 
 
 if ($file -like "*.Tests.ps1") {


### PR DESCRIPTION
While working on the #350 I developed a script that makes developing the tests in VS Code that little bit easier, at least for me. So far I kept it out of the project but perhaps that is something that could be included? 

The version I use right now does the following after hitting F5

* if the open file is an  `*.Assertions.ps1` file and the cursor is outside of tests it will run all the unit tests in the matching `*.Assertions.Tests.ps1` file
* if the open file is an `*.Assertions.ps1` file and the cursor is in one of the `Assert-` functions all unit tests using that method will be executed
* if the open file is an `*.Assertions.Tests.ps1` then depending where the cursor is either specific `Describe` block is executed or the whole file
* if it is one of the check files the behaviour is similar, but with an option to either run unit tests for that check or file, or execute the check or all of the checks from the file. 

Obviously all of that doesn't make any sense until we have the changes I'm working on, so I have a simpler version in this pull request which simply runs a check from under the cursor. Something to start the discussion. 

To use it I have the following configuration in my `launch.json`
```json
       {
            "type": "PowerShell",
            "request": "launch",
            "name": "Test workinprogress",
            "script": "${workspaceFolder}/internal/scripts/workinprogress.ps1",
            "args": [ "${workspaceFolder}", "${file}", "${fileBasename}", "${lineNumber}" ]
        }
```