### PR TITLE
Revert "updated for faster/more robust module versions"

### DIFF
--- a/dbachecks.psd1
+++ b/dbachecks.psd1
@@ -50,8 +50,8 @@
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules        = @(
         @{ ModuleName = 'Pester'; ModuleVersion = '4.2.0' },
-        @{ ModuleName = 'dbatools'; ModuleVersion = '0.9.317' }
-        @{ ModuleName = 'PSFramework'; ModuleVersion = '0.9.13.34' }
+        @{ ModuleName = 'dbatools'; ModuleVersion = '0.9.300' }
+        @{ ModuleName = 'PSFramework'; ModuleVersion = '0.9.10.23' }
     )
     
     # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
Reverts sqlcollaborative/dbachecks#416

Reverts due to error in PSFramework

 ParameterBindingException: A parameter cannot be found that matches parameter name 'Depth'.
        at Write-Config, <No file>: line 104
        at Register-PSFConfig<Process>, <No file>: line 181
        at Set-DbcConfig<Process>, <No file>: line 73
        at Import-DbcConfig<Process>, <No file>: line 53
       