### PR TITLE
Exclude database fix

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -4,6 +4,7 @@ Describe "Database Collation" -Tags DatabaseCollation, $filename {
     $Wrongcollation = Get-DbcConfigValue policy.database.wrongcollation
     $exclude = "ReportingServer", "ReportingServerTempDB"
     $exclude += $Wrongcollation
+    $exclude += $ExcludedDatabases
     @(Get-Instance).ForEach{
         Context "Testing database collation on $psitem" {
             @(Test-DbaDatabaseCollation -SqlInstance $psitem -ExcludeDatabase $exclude ).ForEach{
@@ -143,6 +144,7 @@ Describe "Recovery Model" -Tags RecoveryModel, DISA, $filename {
         $recoverymodel = Get-DbcConfigValue policy.recoverymodel.type
         Context "Testing Recovery Model on $psitem" {
             $exclude = Get-DbcConfigValue policy.recoverymodel.excludedb
+            $exclude += $ExcludedDatabases 
             @(Get-DbaDbRecoveryModel -SqlInstance $psitem -ExcludeDatabase $exclude).ForEach{
                 It "$($psitem.Name) should be set to $recoverymodel on $($psitem.SqlInstance)" {
                     $psitem.RecoveryModel | Should -Be $recoverymodel -Because "You expect this recovery model"
@@ -453,6 +455,7 @@ Describe "Datafile Auto Growth Configuration" -Tags DatafileAutoGrowthType, $fil
     $datafilegrowthtype = Get-DbcConfigValue policy.database.filegrowthtype
     $datafilegrowthvalue = Get-DbcConfigValue policy.database.filegrowthvalue
     $exclude = Get-DbcConfigValue policy.database.filegrowthexcludedb
+    $exclude += $ExcludedDatabases 
     @(Get-Instance).ForEach{
         Context "Testing datafile growth type on $psitem" {
             @(Get-DbaDatabaseFile -SqlInstance $psitem -ExcludeDatabase $exclude ).ForEach{

--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -26,7 +26,7 @@ Describe "Database Collation" -Tags DatabaseCollation, $filename {
 Describe "Suspect Page" -Tags SuspectPage, $filename {
     @(Get-Instance).ForEach{
         Context "Testing suspect pages on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 $results = Get-DbaSuspectPage -SqlInstance $psitem.Parent -Database $psitem.Name
                 It "$($psitem.Name) should return 0 suspect pages on $($psitem.Parent.Name)" {
                     @($results).Count | Should -Be 0 -Because "You do not want suspect pages"
@@ -43,7 +43,8 @@ Describe "Last Backup Restore Test" -Tags TestLastBackup, Backup, $filename {
         $destlog = Get-DbcConfigValue policy.backup.logdir
         @(Get-Instance).ForEach{
             Context "Testing Backup Restore & Integrity Checks on $psitem" {
-                @(Test-DbaLastBackup -SqlInstance $psitem -Destination $destserver -LogDirectory $destlog -DataDirectory $destdata).ForEach{
+            @(Test-DbaLastBackup -SqlInstance $psitem -Database ((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).Name -VerifyOnly).ForEach{
+                    
                     if ($psitem.DBCCResult -notmatch "skipped for restored master") {
                         It "DBCC for $($psitem.Database) on $($psitem.SourceServer) Should Be success" {
                             $psitem.DBCCResult | Should -Be "Success" -Because "You need to run DBCC CHECKDB to ensure your database is consistent"
@@ -62,7 +63,7 @@ Describe "Last Backup VerifyOnly" -Tags TestLastBackupVerifyOnly, Backup, $filen
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
     @(Get-Instance).ForEach{
         Context "VerifyOnly tests of last backups on $psitem" {
-            @(Test-DbaLastBackup -SqlInstance $psitem -Database ((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.CreateDate -lt (Get-Date).AddHours( - $graceperiod)}).Name -VerifyOnly).ForEach{
+            @(Test-DbaLastBackup -SqlInstance $psitem -Database ((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).Name -VerifyOnly).ForEach{
                 It "restore for $($psitem.Database) on $($psitem.SourceServer) Should be success" {
                     $psitem.RestoreResult | Should -Be "Success" -Because "The restore file has not successfully restored - you have no backup"
                 }
@@ -79,7 +80,7 @@ Describe "Valid Database Owner" -Tags ValidDatabaseOwner, $filename {
     [string[]]$exclude = Get-DbcConfigValue policy.validdbowner.excludedb
     @(Get-Instance).ForEach{
         Context "Testing Database Owners on $psitem" {
-            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -notin $exclude}).ForEach{
+            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -notin $exclude -and ($ExcludedDatabases -notcontains $_.Name)}).ForEach{
                 It "Database $($psitem.Name) - owner $($psitem.Owner) should be in this list ( $( [String]::Join(", ", $targetowner) ) ) on $($psitem.Parent.Name)" {
                     $psitem.Owner | Should -BeIn $TargetOwner -Because "The account that is the database owner is not what was expected"
                 }
@@ -93,7 +94,7 @@ Describe "Invalid Database Owner" -Tags InvalidDatabaseOwner, $filename {
     [string[]]$exclude = Get-DbcConfigValue policy.invaliddbowner.excludedb
     @(Get-Instance).ForEach{
         Context "Testing Database Owners on $psitem" {
-            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -notin $exclude}).ForEach{
+            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -notin $exclude -and ($ExcludedDatabases -notcontains $_.Name)}).ForEach{
                 It "Database $($psitem.Name) - owner $($psitem.Owner) should Not be in this list ( $( [String]::Join(", ", $targetowner) ) ) on $($psitem.Parent.Name)" {
                     $psitem.Owner | Should -Not -BeIn $TargetOwner -Because "The database owner was one specified as incorrect"
                 }
@@ -108,7 +109,7 @@ Describe "Last Good DBCC CHECKDB" -Tags LastGoodCheckDb, $filename {
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
     @(Get-Instance).ForEach{
         Context "Testing Last Good DBCC CHECKDB on $psitem" {
-            @(Get-DbaLastGoodCheckDb -SqlInstance $psitem -Database ((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.CreateDate -lt (Get-Date).AddHours( - $graceperiod)}).Name).ForEach{
+            @(Get-DbaLastGoodCheckDb -SqlInstance $psitem -Database ((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($_.IsAccessible -eq $true) -and ($ExcludedDatabases -notcontains $_.Name)}).Name ).ForEach{
                 if ($psitem.Database -ne "tempdb") {
                     It "last good integrity check for $($psitem.Database) on $($psitem.SqlInstance) Should Be less than $maxdays days old" {
                         $psitem.LastGoodCheckDb | Should -BeGreaterThan (Get-Date).AddDays( - ($maxdays)) -Because "You should have run a DBCC CheckDB inside that time"
@@ -157,7 +158,7 @@ Describe "Recovery Model" -Tags RecoveryModel, DISA, $filename {
 Describe "Duplicate Index" -Tags DuplicateIndex, $filename {
     @(Get-Instance).ForEach{
         Context "Testing duplicate indexes on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 $results = Find-DbaDuplicateIndex -SqlInstance $psitem.Parent -Database $psitem.Name
                 It "$($psitem.Name) on $($psitem.Parent.Name) should return 0 duplicate indexes" {
                     @($results).Count | Should -Be 0 -Because "Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory"
@@ -189,7 +190,7 @@ Describe "Unused Index" -Tags UnusedIndex, $filename {
 Describe "Disabled Index" -Tags DisabledIndex, $filename {
     @(Get-Instance).ForEach{
         Context "Testing Disabled indexes on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name -and ($_.IsAccessible -eq $true)}.ForEach{
                 $results = Find-DbaDisabledIndex -SqlInstance $psitem.Parent -Database $psitem.Name
                 It "$($psitem.Name) on $($psitem.Parent.Name) should return 0 Disabled indexes" {
                     @($results).Count | Should -Be 0 -Because "Disabled indexes are wasting disk space"
@@ -202,7 +203,7 @@ Describe "Disabled Index" -Tags DisabledIndex, $filename {
 Describe "Database Growth Event" -Tags DatabaseGrowthEvent, $filename {
     @(Get-Instance).ForEach{
         Context "Testing database growth event on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 $results = Find-DbaDbGrowthEvent -SqlInstance $psitem.Parent -Database $psitem.Name
                 It "$($psitem.Name) should return 0 database growth events on $($psitem.Parent.Name)" {
                     @($results).Count | Should -Be 0 -Because "You want to control how your database files are grown"
@@ -216,7 +217,7 @@ Describe "Page Verify" -Tags PageVerify, $filename {
     $pageverify = Get-DbcConfigValue policy.pageverify
     @(Get-Instance).ForEach{
         Context "Testing page verify on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 It "$($psitem.Name) on $($psitem.Parent.Name) should have page verify set to $pageverify" {
                     $psitem.PageVerify | Should -Be $pageverify -Because "Page verify helps SQL Server to detect corruption"
                 }
@@ -229,7 +230,7 @@ Describe "Auto Close" -Tags AutoClose, $filename {
     $autoclose = Get-DbcConfigValue policy.database.autoclose
     @(Get-Instance).ForEach{
         Context "Testing Auto Close on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 It "$($psitem.Name) on $($psitem.Parent.Name) should have Auto Close set to $autoclose" {
                     $psitem.AutoClose | Should -Be $autoclose -Because "Because!"
                 }
@@ -242,7 +243,7 @@ Describe "Auto Shrink" -Tags AutoShrink, $filename {
     $autoshrink = Get-DbcConfigValue policy.database.autoshrink
     @(Get-Instance).ForEach{
         Context "Testing Auto Shrink on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 It "$($psitem.Name) on $($psitem.Parent.Name) should have Auto Shrink set to $autoshrink" {
                     $psitem.AutoShrink | Should -Be $autoshrink -Because "Shrinking databases causes fragmentation and performance issues"
                 }
@@ -256,7 +257,7 @@ Describe "Last Full Backup Times" -Tags LastFullBackup, LastBackup, Backup, DISA
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
     @(Get-Instance).ForEach{
         Context "Testing last full backups on $psitem" {
-            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ ($psitem.Name -ne 'tempdb') -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) }).ForEach{
+            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ ($psitem.Name -ne 'tempdb') -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
                 $offline = ($psitem.Status -match "Offline")
                 It -Skip:$offline "$($psitem.Name) full backups on $($psitem.Parent.Name) Should Be less than $maxfull days" {
                     $psitem.LastBackupDate | Should -BeGreaterThan (Get-Date).AddDays( - ($maxfull)) -Because "Taking regular backups is extraordinarily important"
@@ -272,7 +273,7 @@ Describe "Last Diff Backup Times" -Tags LastDiffBackup, LastBackup, Backup, DISA
         $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
         @(Get-Instance).ForEach{
             Context "Testing last diff backups on $psitem" {
-                @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) }).ForEach{
+                @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
                     $offline = ($psitem.Status -match "Offline")
                     It -Skip:$offline "$($psitem.Name) diff backups on $($psitem.Parent.Name) Should Be less than $maxdiff hours" {
                         $psitem.LastDifferentialBackupDate | Should -BeGreaterThan (Get-Date).AddHours( - ($maxdiff)) -Because 'Taking regular backups is extraordinarily important'
@@ -288,7 +289,7 @@ Describe "Last Log Backup Times" -Tags LastLogBackup, LastBackup, Backup, DISA, 
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
     @(Get-Instance).ForEach{
         Context "Testing last log backups on $psitem" {
-            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) }).ForEach{
+            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
                 if ($psitem.RecoveryModel -ne "Simple") {
                     $offline = ($psitem.Status -match "Offline")
                     It -Skip:$offline "$($psitem.Name) log backups on $($psitem.Parent.Name) Should Be less than $maxlog minutes" {
@@ -320,7 +321,7 @@ Describe "Log File Count Checks" -Tags LogfileCount, $filename {
     If (-not $LogFileCountTest) {
         @(Get-Instance).ForEach{
             Context "Testing Log File count and size for $psitem" {
-                @((Connect-DbaInstance -SqlInstance $psitem).Databases).ForEach{
+                @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $_.Name}).ForEach{
                     $Files = Get-DbaDatabaseFile -SqlInstance $psitem.Parent.Name -Database $psitem.Name
                     $LogFiles = $Files | Where-Object {$_.TypeDescription -eq "LOG"}
                     It "$($psitem.Name) on $($psitem.Parent.Name) Should have less than $LogFileCount Log files" {
@@ -337,7 +338,7 @@ Describe "Log File Size Checks" -Tags LogfileSize, $filename {
     $LogFileSizeComparison = Get-DbcConfigValue policy.database.logfilesizecomparison
     @(Get-Instance).ForEach{
         Context "Testing Log File count and size for $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 $Files = Get-DbaDatabaseFile -SqlInstance $psitem.Parent.Name -Database $psitem.Name
                 $LogFiles = $Files | Where-Object {$_.TypeDescription -eq "LOG"}
                 $Splat = @{$LogFileSizeComparison = $true;
@@ -358,7 +359,7 @@ Describe "Future File Growth" -Tags FutureFileGrowth, $filename {
     $exclude = Get-DbcConfigValue policy.database.filegrowthexcludedb
     @(Get-Instance).ForEach{
         Context "Testing for files likely to grow soon on $psitem" {
-            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -notin $exclude}).ForEach{
+            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -notin $exclude -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
                 $Files = Get-DbaDatabaseFile -SqlInstance $psitem.Parent.Name -Database $psitem.Name
                 $Files | Add-Member ScriptProperty -Name PercentFree -Value {100 - [Math]::Round(([int64]$PSItem.UsedSpace.Byte / [int64]$PSItem.Size.Byte) * 100, 3)}
                 $Files | ForEach-Object {
@@ -378,7 +379,7 @@ Describe "Correctly sized Filegroup members" -Tags FileGroupBalanced, $filename 
     $Tolerance = Get-DbcConfigValue policy.database.filebalancetolerance
     @(Get-Instance).ForEach{
         Context "Testing for balanced FileGroups on $psitem" {
-            @((Connect-DbaInstance -SqlInstance $_).Databases).ForEach{
+            @((Connect-DbaInstance -SqlInstance $_).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}).ForEach{
                 $Files = Get-DbaDatabaseFile -SqlInstance $psitem.Parent.Name -Database $psitem.Name
                 $FileGroups = $Files | Where-Object {$_.TypeDescription -eq "ROWS"} | Group-Object -Property FileGroupName
                 @($FileGroups).ForEach{
@@ -416,7 +417,7 @@ Describe "Auto Create Statistics" -Tags AutoCreateStatistics, $filename {
     $autocreatestatistics = Get-DbcConfigValue policy.database.autocreatestatistics
     @(Get-Instance).ForEach{
         Context "Testing Auto Create Statistics on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 It "$($psitem.Name) on $($psitem.Parent.Name) should have Auto Create Statistics set to $autocreatestatistics" {
                     $psitem.AutoCreateStatisticsEnabled | Should -Be $autocreatestatistics -Because "This is value expeceted for autocreate statistics"
                 }
@@ -429,7 +430,7 @@ Describe "Auto Update Statistics" -Tags AutoUpdateStatistics, $filename {
     $autoupdatestatistics = Get-DbcConfigValue policy.database.autoupdatestatistics
     @(Get-Instance).ForEach{
         Context "Testing Auto Update Statistics on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 It "$($psitem.Name) on $($psitem.Parent.Name) should have Auto Update Statistics set to $autoupdatestatistics" {
                     $psitem.AutoUpdateStatisticsEnabled | Should -Be $autoupdatestatistics  -Because "This is value expeceted for autoupdate statistics"
                 }
@@ -442,7 +443,7 @@ Describe "Auto Update Statistics Asynchronously" -Tags AutoUpdateStatisticsAsync
     $autoupdatestatisticsasynchronously = Get-DbcConfigValue policy.database.autoupdatestatisticsasynchronously
     @(Get-Instance).ForEach{
         Context "Testing Auto Update Statistics Asynchronously on $psitem" {
-            @(Connect-DbaInstance -SqlInstance $psitem).Databases.ForEach{
+            @(Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$ExcludedDatabases -notcontains $PsItem.Name}.ForEach{
                 It "$($psitem.Name) on $($psitem.Parent.Name) should have Auto Update Statistics Asynchronously set to $autoupdatestatisticsasynchronously" {
                     $psitem.AutoUpdateStatisticsAsync | Should -Be $autoupdatestatisticsasynchronously  -Because "This is value expeceted for autoupdate statistics asynchronously"
                 }
@@ -482,7 +483,7 @@ Describe "Datafile Auto Growth Configuration" -Tags DatafileAutoGrowthType, $fil
 Describe "Trustworthy Option" -Tags Trustworthy, DISA, $filename {
     @(Get-Instance).ForEach{
         Context "Testing database trustworthy option on $psitem" {
-            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -ne 'msdb'}).ForEach{
+            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -ne 'msdb' -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
                 It "Trustworthy is set to false on $($psitem.Name)" {
                     $psitem.Trustworthy | Should -BeFalse -Because "Trustworthy has security implications and may expose your SQL Server to additional risk"
                 }
@@ -505,7 +506,7 @@ Describe "Database Orphaned User" -Tags OrphanedUser, $filename {
 Describe "PseudoSimple Recovery Model" -Tags PseudoSimple, $filename {
     @(Get-Instance).ForEach{
         Context "Testing database is not in PseudoSimple recovery model on $psitem" {
-            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -ne 'tempdb'}).ForEach{
+            @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{$_.Name -ne 'tempdb' -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
                 It "$($psitem.Name) has PseudoSimple recovery model equal false on $($psitem.Parent.Name)" {
                     (Test-DbaFullRecoveryModel -SqlInstance $psitem.Parent -Database $psitem.Name).ActualRecoveryModel -eq "pseudo-SIMPLE" | Should -BeFalse -Because "PseudoSimple means that a FULL backup has not been taken and the database is still effectively in SIMPLE mode"
                 }

--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -306,7 +306,7 @@ Describe "Virtual Log Files" -Tags VirtualLogFile, $filename {
     $vlfmax = Get-DbcConfigValue policy.database.maxvlf
     @(Get-Instance).ForEach{
         Context "Testing Database VLFs on $psitem" {
-            @(Test-DbaDbVirtualLogFile -SqlInstance $_).ForEach{
+            @(Test-DbaDbVirtualLogFile -SqlInstance $_ -ExcludeDatabase $ExcludedDatabases).ForEach{
                 It "$($psitem.Database) VLF count on $($psitem.SqlInstance) Should Be less than $vlfmax" {
                     $psitem.Total | Should -BeLessThan $vlfmax -Because "Too many VLFs can impact performance and slow down backup/restore"
                 }
@@ -518,7 +518,7 @@ Describe "PseudoSimple Recovery Model" -Tags PseudoSimple, $filename {
 Describe "Compatibility Level" -Tags CompatibilityLevel, $filename {
     @(Get-Instance).ForEach{
         Context "Testing database compatibility level matches server compatibility level on $psitem" {
-            @(Test-DbaDatabaseCompatibility -SqlInstance $psitem).ForEach{
+            @(Test-DbaDatabaseCompatibility -SqlInstance $psitem -ExcludeDatabase $ExcludedDatabases).ForEach{
                 It "$($psitem.Database) has a database compatibility level equal to the level of $($psitem.SqlInstance)" {
                     $psItem.DatabaseCompatibility | Should -Be $psItem.ServerLevel -Because "it means you are on the appropriate compatibility level for your SQL Server version to use all available features"
                 }

--- a/functions/Invoke-DbcCheck.ps1
+++ b/functions/Invoke-DbcCheck.ps1
@@ -301,7 +301,7 @@
 
         
         $globalexcludedchecks = Get-PSFConfigValue -FullName dbachecks.command.invokedbccheck.excludecheck
-        $Script:ExcludedDatabases = Get-PSFConfigValue -FullName dbachecks.command.invokedbccheck.excludedatabases
+        [string[]]$Script:ExcludedDatabases = Get-PSFConfigValue -FullName dbachecks.command.invokedbccheck.excludedatabases
         $Script:ExcludedDatabases += $ExcludeDatabase
 
         

--- a/functions/Invoke-DbcCheck.ps1
+++ b/functions/Invoke-DbcCheck.ps1
@@ -301,7 +301,7 @@
 
         
         $globalexcludedchecks = Get-PSFConfigValue -FullName dbachecks.command.invokedbccheck.excludecheck
-        $Script:ExcludedDatabases = Get-PSFConfigValue -FullName dbachecks.command.invokedbccheck.excludedatabase
+        $Script:ExcludedDatabases = Get-PSFConfigValue -FullName dbachecks.command.invokedbccheck.excludedatabases
         $Script:ExcludedDatabases += $ExcludeDatabase
 
         

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -200,3 +200,4 @@ Set-PSFConfig -Module dbachecks -Name mail.subject  -Value 'dbachecks results' -
 
 # Command parameter default values
 Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludecheck -Value @() -Initialize -Description "Invoke-DbcCheck: The checks that should be skipped by default."
+Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludedatabase -Value @() -Initialize -Description "Invoke-DbcCheck: The databases that should be skipped by default."

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -200,4 +200,4 @@ Set-PSFConfig -Module dbachecks -Name mail.subject  -Value 'dbachecks results' -
 
 # Command parameter default values
 Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludecheck -Value @() -Initialize -Description "Invoke-DbcCheck: The checks that should be skipped by default."
-Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludedatabase -Value @() -Initialize -Description "Invoke-DbcCheck: The databases that should be skipped by default."
+Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludedatabases -Value @() -Initialize -Description "Invoke-DbcCheck: The databases that should be skipped by default."


### PR DESCRIPTION


## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

This PR closes #341 and adds a new config for excluding databases globally

It has been tested by

````
$tests = Invoke-DbcCheck -SqlInstance rob-xps -Check Database -ExcludeDatabase Beardlive -PassThru
$tests | ConvertTo-Json | clip

#Check for beardlive in json - none found

$tests = Invoke-DbcCheck -SqlInstance rob-xps -Check Database -ExcludeDatabase Beardlive,ProviderDemo -PassThru
$tests | ConvertTo-Json | clip

#Check for beardlive and Providerdemo in json - none found

Set-DbcConfig -Name command.invokedbccheck.excludedatabases Beardlive
$tests = Invoke-DbcCheck -SqlInstance rob-xps -Check Database  -PassThru -Show Fails

$tests | ConvertTo-Json | clip

#Check for beardlive in json - none found

Set-DbcConfig -Name command.invokedbccheck.excludedatabases Beardlive, ProviderDemo
$tests = Invoke-DbcCheck -SqlInstance rob-xps -Check Database -ExcludeDatabase Beardlive,ProviderDemo -PassThru
$tests | ConvertTo-Json | clip

Set-DbcConfig -Name command.invokedbccheck.excludedatabases
$tests = Invoke-DbcCheck -SqlInstance rob-xps -Check Database  -PassThru -Show Fails

#No errros

````