### PR TITLE
pop-location after execution was cancelled

### DIFF
--- a/tests/Get-DatabaseDetail.Tests.ps1
+++ b/tests/Get-DatabaseDetail.Tests.ps1
@@ -4,7 +4,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 $sqlinstance = "localhost"
 
-Describe "Integration testing of $commandname" -Tags IntegrationTests,SqlIntegrationTests, Integration {
+Describe "Integration testing of $commandname" -Tags SqlIntegrationTests,IntegrationTests {
     @($sqlinstance).ForEach{
         Context "Collecting database details for checks from $psitem" {
             BeforeAll {


### PR DESCRIPTION
this PR changes behaviour of Inoke-DbcCheck in an event of test cancellation (ctrl+c). 
So far we were left in the custom or default repo folder. Now, with this change, even if the test is cancelled the pop-location is executed, and the location is exactly as when the execution started. As a bonus a warning message appears to notify the user that the execution was cancelled. 

![image](https://user-images.githubusercontent.com/120880/38190920-5e1eb6ee-365e-11e8-8f26-1e55d6d8f526.png)

All the tests have been run, no errors reported. 