### PR TITLE
Configurable SQL Instance(s) for Integration Testing

### DIFF
--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -204,4 +204,4 @@ Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludedatabases -V
 
 
 # config for integration testing 
-Set-PSFConfig -Module dbachecks -Name testing.integration.instance -Value "localhost" -Initialize -Validation String -Description "Default SQL Server instances to be used by integration tests"
+Set-PSFConfig -Module dbachecks -Name testing.integration.instance -Value @("localhost") -Initialize -Description "Default SQL Server instances to be used by integration tests"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -201,3 +201,7 @@ Set-PSFConfig -Module dbachecks -Name mail.subject  -Value 'dbachecks results' -
 # Command parameter default values
 Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludecheck -Value @() -Initialize -Description "Invoke-DbcCheck: The checks that should be skipped by default."
 Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludedatabases -Value @() -Initialize -Description "Invoke-DbcCheck: The databases that should be skipped by default."
+
+
+# config for integration testing 
+Set-PSFConfig -Module dbachecks -Name testing.integration.instance -Value "localhost" -Initialize -Validation String -Description "Default SQL Server instances to be used by integration tests"

--- a/tests/Get-DatabaseDetail.Tests.ps1
+++ b/tests/Get-DatabaseDetail.Tests.ps1
@@ -2,10 +2,9 @@ $commandname = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot/../internal/functions/Get-DatabaseDetail.ps1"
 
-$sqlinstance = "localhost"
 
-Describe "Integration testing of $commandname" -Tags IntegrationTests,SqlIntegrationTests, Integration {
-    @($sqlinstance).ForEach{
+Describe "Integration testing of $commandname" -Tags IntegrationTests, SqlIntegrationTests {
+    @(Get-DbcConfigValue testing.integration.instance).ForEach{
         Context "Collecting database details for checks from $psitem" {
             BeforeAll {
                 $expectedProperties = @{

--- a/tests/Invoke-DbcCheck.Tests.ps1
+++ b/tests/Invoke-DbcCheck.Tests.ps1
@@ -2,11 +2,13 @@
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
-Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
-    Context "Command executes properly and returns proper info" {
-        It "runs a check" {
-            $results = Invoke-DbcCheck -ComputerName localhost -Tag DiskCapacity -Passthru -Show None
-            $results.TestResult | Should Not Be $null # Because nothing else works right now
+Describe "$commandname Integration Tests" -Tags IntegrationTests {
+    @(Get-DbcConfigValue testing.integration.instance).ForEach{
+        Context "Command executes properly and returns proper info on $psitem" {
+            It "runs a check" {
+                $results = Invoke-DbcCheck -ComputerName localhost -Tag DiskCapacity -Passthru -Show None
+                $results.TestResult | Should Not Be $null # Because nothing else works right now
+            }
         }
     }
 }

--- a/tests/Invoke-DbcCheck.Tests.ps1
+++ b/tests/Invoke-DbcCheck.Tests.ps1
@@ -6,7 +6,7 @@ Describe "$commandname Integration Tests" -Tags IntegrationTests {
     @(Get-DbcConfigValue testing.integration.instance).ForEach{
         Context "Command executes properly and returns proper info on $psitem" {
             It "runs a check" {
-                $results = Invoke-DbcCheck -ComputerName localhost -Tag DiskCapacity -Passthru -Show None
+                $results = Invoke-DbcCheck -ComputerName $psitem -Tag DiskCapacity -Passthru -Show None
                 $results.TestResult | Should Not Be $null # Because nothing else works right now
             }
         }


### PR DESCRIPTION
Integration testing are sometimes necessary. The problem is that they typically depend on an environment. In my case, the instance names are different depending on where I work on dbachecks, and in some cases I'd like the ability to run the tests only on one instance, sometimes on multipleones. And I'd like to be able to do it without any code changes. 

And now I can, and so can you

```PowerShell
Set-DbcConfig -Name testing.integration.instance -value localhost\myinstance
```
or 
```PowerShell
Set-DbcConfig -Name testing.integration.instance -value localhost\myinstance1, localhost\myinstance2
```

All tests are passing