### PR TITLE
The Sea of Green

### DIFF
--- a/functions/Invoke-DbcCheck.ps1
+++ b/functions/Invoke-DbcCheck.ps1
@@ -325,34 +325,8 @@
         $repos = Get-CheckRepo
         foreach ($repo in $repos) {
             if ((Test-Path $repo -ErrorAction SilentlyContinue)) {
-
-                $selectedScripts = New-Object System.Collections.Generic.List[String]
-                if ($Script -ne $null) { 
-                    # respect the specific script file passed by parameter name
-                    $selectedScripts.Add($Script) 
-                } elseif ($Check.Count -gt 0) { 
-                    # specific checks were requested. find them.
-                    (Get-ChildItem "$repo\*.Tests.ps1").ForEach{
-                        $checksFile = $psitem.FullName
-                        
-                        if ($Check -contains ($PSItem.Name -replace ".Tests.ps1", "")) {
-                            # file matches by name 
-                            $selectedScripts.Add($checksFile)
-                        } else {
-                            @($check).ForEach{
-                                if (@(Select-String -Path $checksFile -Pattern "^Describe.*-Tags\s+.*($psitem)[`",\s]+[,\w]?.*`$").Matches.Count) {
-                                    # file matches by one of the tags
-                                    if (!($selectedScripts -contains $checksFile)) {
-                                        $selectedScripts.Add($checksFile)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                
-                if ($AllChecks) {
-                    # process whole repository 
+                if ($AllChecks -or $Script) {
+                    # process the whole repository or specific script which was provided
                     if ($OutputFormat -eq "NUnitXml" -and -not $OutputFile) {
                         $number = $repos.IndexOf($repo)
                         $timestamp = Get-Date -format "yyyyMMddHHmmss"
@@ -362,7 +336,8 @@
                     Invoke-Pester @PSBoundParameters
                     Pop-Location
                 } else {
-                    @($selectedScripts).ForEach{
+                    # find the check files with matching tags and execute those
+                    (Get-CheckFile -Repo $repo -Check $check).ForEach{
                         if ($OutputFormat -eq "NUnitXml" -and -not $OutputFile) {
                             $number = $repos.IndexOf($repo)
                             $timestamp = Get-Date -format "yyyyMMddHHmmss"

--- a/functions/Invoke-DbcCheck.ps1
+++ b/functions/Invoke-DbcCheck.ps1
@@ -325,27 +325,20 @@
         $repos = Get-CheckRepo
         foreach ($repo in $repos) {
             if ((Test-Path $repo -ErrorAction SilentlyContinue)) {
-                if ($AllChecks -or $Script) {
-                    # process the whole repository or specific script which was provided
-                    if ($OutputFormat -eq "NUnitXml" -and -not $OutputFile) {
-                        $number = $repos.IndexOf($repo)
-                        $timestamp = Get-Date -format "yyyyMMddHHmmss"
-                        $PSBoundParameters['OutputFile'] = "$script:maildirectory\report-$number-$pid-$timestamp.xml"
-                    }
-                    Push-Location -Path $repo
-                    Invoke-Pester @PSBoundParameters
-                    Pop-Location
-                } else {
-                    # find the check files with matching tags and execute those
-                    (Get-CheckFile -Repo $repo -Check $check).ForEach{
-                        if ($OutputFormat -eq "NUnitXml" -and -not $OutputFile) {
-                            $number = $repos.IndexOf($repo)
-                            $timestamp = Get-Date -format "yyyyMMddHHmmss"
-                            $PSBoundParameters['OutputFile'] = "$script:maildirectory\report-$number-$pid-$timestamp.xml"
-                        }
-                        Invoke-Pester -Script $PSItem @PSBoundParameters
-                    }
+                if ($OutputFormat -eq "NUnitXml" -and -not $OutputFile) {
+                    $number = $repos.IndexOf($repo)
+                    $timestamp = Get-Date -format "yyyyMMddHHmmss"
+                    $PSBoundParameters['OutputFile'] = "$script:maildirectory\report-$number-$pid-$timestamp.xml"
                 }
+
+                if ($Check.Count -gt 0) {
+                    # specific checks were listed. find the necessary script files. 
+                    $PSBoundParameters['Script'] = (Get-CheckFile -Repo $repo -Check $check)
+                }
+
+                Push-Location -Path $repo
+                Invoke-Pester @PSBoundParameters
+                Pop-Location
             }
         }
     }

--- a/internal/functions/Get-CheckFile.ps1
+++ b/internal/functions/Get-CheckFile.ps1
@@ -1,0 +1,35 @@
+function Get-CheckFile {
+    param(
+        [Parameter(Mandatory=$true)]
+        [String]$Repo,
+        [Parameter(Mandatory=$true)]
+        [String[]]$Check
+    )
+    
+    $script:selectedFiles = New-Object System.Collections.Generic.List[String]
+
+    if ($Check.Count -gt 0) { 
+        # specific checks were requested. find them.
+        (Get-ChildItem -Path "$Repo\*.Tests.ps1").ForEach{
+            $script:checksFile = $psitem.FullName
+            
+            if ($Check -contains ($PSItem.Name -replace ".Tests.ps1", "")) {
+                # file matches by name 
+                if (!($script:selectedFiles -contains $script:checksFile)) {
+                    $script:selectedFiles.Add($script:checksFile)
+                }
+            } else {
+                @($check).ForEach{
+                    if (@(Get-Content -Path $script:checksFile | Select-String -Pattern "^Describe.*-Tags\s+.*($psitem)[`",\s]+[,\w]?.*`$").Matches.Count) {
+                        # file matches by one of the tags
+                        if (!($script:selectedFiles -contains $script:checksFile)) {
+                            $script:selectedFiles.Add($script:checksFile)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return $script:selectedFiles
+}

--- a/tests/Get-CheckFile.Tests.ps1
+++ b/tests/Get-CheckFile.Tests.ps1
@@ -1,0 +1,131 @@
+$commandname = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot/../internal/functions/Get-CheckFile.ps1"
+
+Describe "Testing Get-CheckFile function" {
+    Mock Get-ChildItem { 
+        return @(
+            @{ Name = "One.Tests.ps1"; FullName = "C:\Checks\One.Tests.ps1" },
+            @{ Name = "Two.Tests.ps1"; FullName = "C:\Checks\Two.Tests.ps1" },
+            @{ Name = "Three.Tests.ps1"; FullName = "C:\Checks\Three.Tests.ps1" }
+        )
+    } -ParameterFilter { $Path }
+
+    Mock Get-Content {
+        return "
+# some comments to start with 
+
+Describe `"First fake check`" -Tags FirstCheck {
+    Context `"Some context`" {
+    }
+}
+
+Describe `"Second fake check`" -Tags SecondCheck, `$filename {
+    Context `"Some context`" {
+    }
+}
+
+Describe `"Third fake check`" -Tags ThirdCheck, `$filename {
+    Context `"Some context`" {
+    }
+}
+        ".Split([Environment]::NewLine)
+    } -ParameterFilter { $Path -eq "C:\Checks\One.Tests.ps1" }
+
+    Mock Get-Content {
+        return "
+`$filename = `$MyInvocation.MyCommand.Name.Replace(`".Tests.ps1`", `"`")
+
+Describe `"Fourth fake check`" -Tags FourthCheck, CommonTag, `$filename {
+    Context `"Some context`" {
+    }
+}
+
+Describe `"Fifth fake check`" -Tags FifthCheck,CommonTag,`$filename {
+    Context `"Some context`" {
+    }
+}
+
+# some comments at the end of a file, perhaps a function definition
+function Get-MeSomeStuff {
+    param([string]`$whatToGet)
+    process { }
+}
+        ".Split([Environment]::NewLine)
+    } -ParameterFilter { $Path -eq "C:\Checks\Two.Tests.ps1" }
+
+    Mock Get-Content {
+        return "
+Describe `"Sixth fake check`" -Tags `"SixthCheck`" {
+    Context `"Some context`" {
+    }
+}
+        ".Split([Environment]::NewLine)
+    } -ParameterFilter { $Path -eq "C:\Checks\Three.Tests.ps1" }
+
+    Context "Testing with files matching by name" {
+        $cases = @(
+            @{ CheckValue = "One"; MatchingFile = "C:\Checks\One.Tests.ps1" }
+            @{ CheckValue = "Two"; MatchingFile = "C:\Checks\Two.Tests.ps1" }
+            @{ CheckValue = "Three"; MatchingFile = "C:\Checks\Three.Tests.ps1" }
+        )
+
+        It "<MatchingFile> is found when Check is <CheckValue>" -TestCases $cases {
+            param([String]$CheckValue, [String]$MatchingFile)
+            $result = @(Get-CheckFile -Repo "FakeRepo" -Check $CheckValue)
+            $result.Count | Should -Be 1 -Because "we expect exactly one file"
+            $result[0] | Should -Be $MatchingFile -Because "we expect specific file"
+        }
+
+        It "When two files match, both should be returned" {
+            $result = @(Get-CheckFile -Repo "FakeRepo" -Check One,three)
+            $result.Count | Should -Be 2 -Because "we expect exactly two files, one and three"
+        }
+    }
+
+    Context "Testing with files matching by tag" {
+        $cases = @(
+            @{ CheckValue = "FirstCheck"; MatchingFile = "C:\Checks\One.Tests.ps1" }
+            @{ CheckValue = "SecondCheck"; MatchingFile = "C:\Checks\One.Tests.ps1" }
+            @{ CheckValue = "ThirdCheck"; MatchingFile = "C:\Checks\One.Tests.ps1" }
+            @{ CheckValue = "FourthCheck"; MatchingFile = "C:\Checks\Two.Tests.ps1" }
+            @{ CheckValue = "FifthCheck"; MatchingFile = "C:\Checks\Two.Tests.ps1" }
+            @{ CheckValue = "SixthCheck"; MatchingFile = "C:\Checks\Three.Tests.ps1" }
+        )
+
+        It "<MatchingFile> is found when Check is <CheckValue>" -TestCases $cases {
+            param([String]$CheckValue, [String]$MatchingFile)
+            $result = @(Get-CheckFile -Repo "FakeRepo" -Check $CheckValue)
+            $result.Count | Should -Be 1 -Because "we expect exactly one file"
+        }
+
+        It "When two files match, both should be returned" {
+            $result = @(Get-CheckFile -Repo "FakeRepo" -Check SecondCheck,SixthCheck)
+            $result.Count | Should -Be 2 -Because "we expect exactly two files, one and three"
+        }
+    }
+
+    Context "Testing to make sure duplicates are not returned" {
+        $cases = @(
+            @{ CheckValue = "One,FirstCheck"; MatchingFile = "C:\Checks\One.Tests.ps1" }
+            @{ CheckValue = "One,FirstCheck,SecondCheck"; MatchingFile = "C:\Checks\One.Tests.ps1" }
+            @{ CheckValue = "Two,FourthCheck,InvalidCheck"; MatchingFile = "C:\Checks\Two.Tests.ps1" }
+            @{ CheckValue = "Three,Three,Three"; MatchingFile = "C:\Checks\Three.Tests.ps1" }
+        )
+
+        It "<MatchingFile> is found when Check is <CheckValue>" -TestCases $cases {
+            param([String]$CheckValue, [String]$MatchingFile)
+            $result = @(Get-CheckFile -Repo "FakeRepo" -Check $CheckValue.Split(","))
+            $result.Count | Should -Be 1 -Because "we expect exactly one file"
+        }
+    }
+    # test for duplicates
+
+
+    Context "Testing things that don't match" {
+        It "If there is no match, no file should be returned" {
+            $result = @(Get-CheckFile -Repo "FakeRepo" -Check "NotMatchingAnything")
+            $result.Count | Should -Be 0 -Because "we don't expect any matches to NotMatchingAnything"
+        }
+    }
+}


### PR DESCRIPTION
The check files are growing in size, and with time will grow in number as well (I have two in mind already). The size of Database.Tests.ps1 makes it harder and harder to digest, and to work with, while the number of files will produce the see of green, even if we want to run just one test. 

Here is my first attempt on limiting it. If specific list of tags is provided, only the files containing those tags will be executed by Invoke-Pester. If `-Script`  or `-AllChecks` parameters are used, the behaviour is at is was. 

Have a look and please let me know what you think.

![image](https://user-images.githubusercontent.com/120880/38197649-44ad3456-3681-11e8-8caf-e82761cc0829.png)
