### PR TITLE
Fixes for Ola Hallengren check

### DIFF
--- a/checks/MaintenanceSolution.Tests.ps1
+++ b/checks/MaintenanceSolution.Tests.ps1
@@ -61,7 +61,7 @@ $jobnames | ForEach-Object {
             
             if ($Retention) {
                 Context "Checking the backup retention on $psitem" {
-                    $jobsteps = $job.JobSteps | Where-Object { $_.SubSystem -eq "CmdExec" }
+                    $jobsteps = $job.JobSteps | Where-Object { $_.SubSystem -eq "CmdExec" -or $_.SubSystem -eq "TransactSql" }
                     if ($jobsteps) {
                         $results = $jobsteps.Command.Split("@") | Where-Object { $_ -match "CleanupTime" }
                     }
@@ -71,7 +71,7 @@ $jobnames | ForEach-Object {
                     
                     It "Is the backup retention set to at least $Retention hours" {
                         if ($results) {
-                            $hours = $results.split("=")[1].split(",").split(" ")[1]
+                            [int]$hours = $results.split("=")[1].split(",").split(" ")[1]
                         }
                         $hours | Should -BeGreaterOrEqual $Retention -Because 'The backup retention needs to be correct'
                     }


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

[x] There are 0 failing Pester tests

## Changes this PR brings

added an `-or` statement when filtering jobs to include the new TransactSQL jobs Ola is creating in the Maintenance Solution. Also explicitly cast `$hours` as an `[int]` to ensure comparison would not be a string against a number from  the config settings. fix for #470 