### PR TITLE
Backup skip readonly

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -260,8 +260,8 @@ Describe "Last Full Backup Times" -Tags LastFullBackup, LastBackup, Backup, DISA
     @(Get-Instance).ForEach{
         Context "Testing last full backups on $psitem" {
             @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ ($psitem.Name -ne 'tempdb') -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
-                $offline = ($psitem.Status -match "Offline")
-                It -Skip:$offline "$($psitem.Name) full backups on $($psitem.Parent.Name) Should Be less than $maxfull days" {
+                $skip = ($psitem.Status -match "Offline")
+                It -Skip:$skip "$($psitem.Name) full backups on $($psitem.Parent.Name) Should Be less than $maxfull days" {
                     $psitem.LastBackupDate | Should -BeGreaterThan (Get-Date).AddDays( - ($maxfull)) -Because "Taking regular backups is extraordinarily important"
                 }
             }
@@ -276,8 +276,8 @@ Describe "Last Diff Backup Times" -Tags LastDiffBackup, LastBackup, Backup, DISA
         @(Get-Instance).ForEach{
             Context "Testing last diff backups on $psitem" {
                 @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
-                    $offline = ($psitem.Status -match "Offline")
-                    It -Skip:$offline "$($psitem.Name) diff backups on $($psitem.Parent.Name) Should Be less than $maxdiff hours" {
+                    $skip = ($psitem.Status -match "Offline")
+                    It -Skip:$skip "$($psitem.Name) diff backups on $($psitem.Parent.Name) Should Be less than $maxdiff hours" {
                         $psitem.LastDifferentialBackupDate | Should -BeGreaterThan (Get-Date).AddHours( - ($maxdiff)) -Because 'Taking regular backups is extraordinarily important'
                     }
                 }
@@ -293,8 +293,8 @@ Describe "Last Log Backup Times" -Tags LastLogBackup, LastBackup, Backup, DISA, 
         Context "Testing last log backups on $psitem" {
             @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
                 if ($psitem.RecoveryModel -ne "Simple") {
-                    $offline = ($psitem.Status -match "Offline")
-                    It -Skip:$offline "$($psitem.Name) log backups on $($psitem.Parent.Name) Should Be less than $maxlog minutes" {
+                    $skip = ($psitem.Status -match "Offline")
+                    It -Skip:$skip  "$($psitem.Name) log backups on $($psitem.Parent.Name) Should Be less than $maxlog minutes" {
                         $psitem.LastLogBackupDate | Should -BeGreaterThan (Get-Date).AddMinutes( - ($maxlog) + 1) -Because "Taking regular backups is extraordinarily important"
                     }
                 }

--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -257,10 +257,11 @@ Describe "Auto Shrink" -Tags AutoShrink, $filename {
 Describe "Last Full Backup Times" -Tags LastFullBackup, LastBackup, Backup, DISA, $filename {
     $maxfull = Get-DbcConfigValue policy.backup.fullmaxdays
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
+    $skipreadonly = Get-DbcConfigValue skip.backup.readonly
     @(Get-Instance).ForEach{
         Context "Testing last full backups on $psitem" {
             @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ ($psitem.Name -ne 'tempdb') -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
-                $skip = ($psitem.Status -match "Offline")
+                $skip = ($psitem.Status -match "Offline") -or ($psitem.Readonly  -eq $true -and $skipreadonly -eq $true)
                 It -Skip:$skip "$($psitem.Name) full backups on $($psitem.Parent.Name) Should Be less than $maxfull days" {
                     $psitem.LastBackupDate | Should -BeGreaterThan (Get-Date).AddDays( - ($maxfull)) -Because "Taking regular backups is extraordinarily important"
                 }
@@ -273,10 +274,11 @@ Describe "Last Diff Backup Times" -Tags LastDiffBackup, LastBackup, Backup, DISA
     if (-not (Get-DbcConfigValue skip.diffbackuptest)) {
         $maxdiff = Get-DbcConfigValue policy.backup.diffmaxhours
         $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
+        $skipreadonly = Get-DbcConfigValue skip.backup.readonly
         @(Get-Instance).ForEach{
             Context "Testing last diff backups on $psitem" {
                 @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
-                    $skip = ($psitem.Status -match "Offline")
+                    $skip = ($psitem.Status -match "Offline") -or ($psitem.Readonly  -eq $true -and $skipreadonly -eq $true)
                     It -Skip:$skip "$($psitem.Name) diff backups on $($psitem.Parent.Name) Should Be less than $maxdiff hours" {
                         $psitem.LastDifferentialBackupDate | Should -BeGreaterThan (Get-Date).AddHours( - ($maxdiff)) -Because 'Taking regular backups is extraordinarily important'
                     }
@@ -289,11 +291,12 @@ Describe "Last Diff Backup Times" -Tags LastDiffBackup, LastBackup, Backup, DISA
 Describe "Last Log Backup Times" -Tags LastLogBackup, LastBackup, Backup, DISA, $filename {
     $maxlog = Get-DbcConfigValue policy.backup.logmaxminutes
     $graceperiod = Get-DbcConfigValue policy.backup.newdbgraceperiod
+    $skipreadonly = Get-DbcConfigValue skip.backup.readonly
     @(Get-Instance).ForEach{
         Context "Testing last log backups on $psitem" {
             @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
                 if ($psitem.RecoveryModel -ne "Simple") {
-                    $skip = ($psitem.Status -match "Offline")
+                    $skip = ($psitem.Status -match "Offline") -or ($psitem.Readonly  -eq $true -and $skipreadonly -eq $true)
                     It -Skip:$skip  "$($psitem.Name) log backups on $($psitem.Parent.Name) Should Be less than $maxlog minutes" {
                         $psitem.LastLogBackupDate | Should -BeGreaterThan (Get-Date).AddMinutes( - ($maxlog) + 1) -Because "Taking regular backups is extraordinarily important"
                     }

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -161,6 +161,7 @@ Set-PSFConfig -Module dbachecks -Name policy.build.warningwindow -Value 6 -Initi
 # skips - these are for whole checks that should not run by default or internal commands that can't be skipped using ExcludeTag
 Set-PSFConfig -Module dbachecks -Name skip.dbcc.datapuritycheck -Validation bool -Value $false -Initialize -Description "Skip data purity check in last good dbcc command"
 Set-PSFConfig -Module dbachecks -Name skip.backup.testing -Validation bool -Value $true -Initialize -Description "Don't run Test-DbaLastBackup by default (it's not read-only)"
+Set-PSFConfig -Module dbachecks -Name skip.backup.readonly -Validation bool -Value $false -Initialize -Description "Check read-only databases for last backup"
 Set-PSFConfig -Module dbachecks -Name skip.tempdb1118 -Validation bool -Value $false -Initialize -Description "Don't run test for Trace Flag 1118"
 Set-PSFConfig -Module dbachecks -Name skip.tempdbfilecount -Validation bool -Value $false -Initialize -Description "Don't run test for Temp Database File Count"
 Set-PSFConfig -Module dbachecks -Name skip.tempdbfilegrowthpercent -Validation bool -Value $false -Initialize -Description "Don't run test for Temp Database File Growth in Percent"
@@ -176,6 +177,7 @@ Set-PSFConfig -Module dbachecks -Name skip.database.logfilecounttest -Validation
 Set-PSFConfig -Module dbachecks -Name skip.logshiptesting -Validation bool -Value $false -Initialize -Description "Skip the logshipping test"
 Set-PSFConfig -Module dbachecks -Name skip.instance.modeldbgrowth -Validation bool -Value $false -Initialize -Description "Skip the model database growth settings test"
 Set-PSFConfig -Module dbachecks -Name skip.hadr.listener.pingcheck -Validation bool -Value $false -Initialize -Description "Skip the HADR listener ping test (expecially useful for Azure and AWS)"
+
 
 #agent
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatorname -Value $null -Initialize -Description "Name of the DBA Operator in SQL Agent"


### PR DESCRIPTION
Added a configuration skip.backup.readonly and logic to skip backup tests fro read-only databases
closes #468 

value set to true (note beardtest set to off-line database set to read-only

![image](https://user-images.githubusercontent.com/6729780/39802523-311ec736-5366-11e8-9fd6-470a2c990749.png)

value set to false

![image](https://user-images.githubusercontent.com/6729780/39802578-5330afc4-5366-11e8-886a-7387d50f68f2.png)
