### PR TITLE
dont check none-accessible databases for backups (AG secondaries)

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -266,7 +266,7 @@ Describe "Last Full Backup Times" -Tags LastFullBackup, LastBackup, Backup, DISA
     @(Get-Instance).ForEach{
         Context "Testing last full backups on $psitem" {
             @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ ($psitem.Name -ne 'tempdb') -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
-                $skip = ($psitem.Status -match "Offline") -or ($psitem.Readonly -eq $true -and $skipreadonly -eq $true)
+                $skip = ($psitem.Status -match "Offline") -or ($psitem.IsAccessible -eq $false)  -or ($psitem.Readonly -eq $true -and $skipreadonly -eq $true)
                 It -Skip:$skip "$($psitem.Name) full backups on $($psitem.Parent.Name) Should Be less than $maxfull days" {
                     $psitem.LastBackupDate | Should -BeGreaterThan (Get-Date).AddDays( - ($maxfull)) -Because "Taking regular backups is extraordinarily important"
                 }
@@ -283,7 +283,7 @@ Describe "Last Diff Backup Times" -Tags LastDiffBackup, LastBackup, Backup, DISA
         @(Get-Instance).ForEach{
             Context "Testing last diff backups on $psitem" {
                 @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
-                    $skip = ($psitem.Status -match "Offline") -or ($psitem.Readonly -eq $true -and $skipreadonly -eq $true)
+                    $skip = ($psitem.Status -match "Offline") -or ($psitem.IsAccessible -eq $false) -or ($psitem.Readonly -eq $true -and $skipreadonly -eq $true)
                     It -Skip:$skip "$($psitem.Name) diff backups on $($psitem.Parent.Name) Should Be less than $maxdiff hours" {
                         $psitem.LastDifferentialBackupDate | Should -BeGreaterThan (Get-Date).AddHours( - ($maxdiff)) -Because 'Taking regular backups is extraordinarily important'
                     }
@@ -301,7 +301,7 @@ Describe "Last Log Backup Times" -Tags LastLogBackup, LastBackup, Backup, DISA, 
         Context "Testing last log backups on $psitem" {
             @((Connect-DbaInstance -SqlInstance $psitem).Databases.Where{ (-not $psitem.IsSystemObject) -and $Psitem.CreateDate -lt (Get-Date).AddHours( - $graceperiod) -and ($ExcludedDatabases -notcontains $PsItem.Name)}).ForEach{
                 if ($psitem.RecoveryModel -ne "Simple") {
-                    $skip = ($psitem.Status -match "Offline") -or ($psitem.Readonly -eq $true -and $skipreadonly -eq $true)
+                    $skip = ($psitem.Status -match "Offline") -or ($psitem.IsAccessible -eq $false) -or ($psitem.Readonly -eq $true -and $skipreadonly -eq $true)
                     It -Skip:$skip  "$($psitem.Name) log backups on $($psitem.Parent.Name) Should Be less than $maxlog minutes" {
                         $psitem.LastLogBackupDate | Should -BeGreaterThan (Get-Date).AddMinutes( - ($maxlog) + 1) -Because "Taking regular backups is extraordinarily important"
                     }


### PR DESCRIPTION
The backup checks were failing on AG secondaries - decided to use isaccessible to check if the dbs should have been backed up