### PR TITLE
Database status - Closes #229

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -570,3 +570,19 @@ Describe "Database MaxDop" -Tags MaxDopDatabase, MaxDop, $filename {
         }
     }
 }
+
+Describe "Database Status" -Tags DatabaseStatus, $filename {
+    . $PSScriptRoot/../internal/assertions/Assert-DatabaseStatus.ps1 
+    $Excludedbs = Get-DbcConfigValue command.invokedbccheck.excludedatabases
+    $ExcludeReadOnly = Get-DbcConfigValue policy.database.status.excludereadonly
+    $ExcludeOffline = Get-DbcConfigValue policy.database.status.excludeoffline
+    $ExcludeRestoring = Get-DbcConfigValue policy.database.status.excluderestoring
+
+    @(Get-Instance).ForEach{
+        Context "Database status is correct on $psitem" {
+            It "All Databases should have the expected status" {
+                Assert-DatabaseStatus -Instance $psitem -Excludedbs $Excludedbs -ExcludeReadOnly $ExcludeReadOnly -ExcludeOffline $ExcludeOffline -ExcludeRestoring $ExcludeRestoring
+            }
+        }
+    }
+}

--- a/internal/assertions/Assert-DatabaseStatus.ps1
+++ b/internal/assertions/Assert-DatabaseStatus.ps1
@@ -1,0 +1,18 @@
+function Assert-DatabaseStatus {
+    Param(
+        [string]$instance,
+        [string[]]$Excludedbs,
+        [string[]]$ExcludeReadOnly,
+        [string[]]$ExcludeOffline,
+        [string[]]$ExcludeRestoring
+    )
+    $results = (Connect-DbaInstance -SqlInstance $Instance).Databases.Where{$psitem.Name -notin $Excludedbs} | Select-Object Name, Status,Readonly
+    $results.Where{$_.Name -notin $ExcludeReadOnly}.Readonly | Should -Not -Contain True -Because "We expect that there will be no Read-Only databases except for those specified"
+    $results.Where{$_.Name -notin $ExcludeOffline}.Status | Should -Not -Match 'Offline' -Because "We expect that there will be no offline databases except for those specified"
+    $results.Where{$_.Name -notin $ExcludeRestoring}.Status | Should -Not -Match 'Restoring' -Because "We expect that there will be no databases in a restoring state except for those specified"
+    $results.Where{$_.Name -notin $ExcludeOffline}.Status | Should -Not -Match 'AutoClosed' -Because "We expect that there will be no databases that have been auto closed"    
+    $results.Status | Should -Not -Match 'Recover' -Because "We expect that there will be no databases going through the recovery process or in a recovery pending state"
+    $results.Status | Should -Not -Match 'Emergency' -Because "We expect that there will be no databases in EmergencyMode"
+    $results.Status | Should -Not -Match 'Standby' -Because "We expect that there will be no databases in Standby"
+    $results.Status | Should -Not -Match 'Suspect' -Because "We expect that there will be no databases in a Suspect state"
+}

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -350,5 +350,9 @@
     {
         "UniqueTag":  "MaxDopDatabase",
         "Description":  "Tests that the database level MaxDop settings for all databases on all instances from version 2016 up are set to the specified value (default 0)"
+    },
+    {
+        "UniqueTag":  "DatabaseStatus",
+        "Description":  "Tests that there are no databases on an instance that are in a state of AutoClose, Offline, ReadOnly, Restoring, Recovery, Recovery Pending, EmergencyMode, Suspect or StandBy. Databases that are in ReadOnly,Offline and Restoring mode can be specified (default none)"
     }
 ]

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -117,7 +117,9 @@ Set-PSFConfig -Module dbachecks -Name policy.database.filebalancetolerance -Valu
 Set-PSFConfig -Module dbachecks -Name policy.database.filegrowthfreespacethreshold -Value 20 -Initialize -Description "Integer representing percentage of free space within a database file before warning"
 Set-PSFConfig -Module dbachecks -Name policy.database.wrongcollation -Value @() -Initialize -Description "Databases that doesnt match server collation check"
 Set-PSFConfig -Module dbachecks -Name policy.database.maxdopexcludedb -Value @() -Initialize -Description "Database Names that we don't want to check for maxdop"
-Set-PSFConfig -Module dbachecks -Name policy.database.maxdop -Value 0 -Initialize -Description "The value for the database maxdop that we expect"
+Set-PSFConfig -Module dbachecks -Name policy.database.status.excludereadonly -Value @() -Initialize -Description "Database names that we expect to be readonly"
+Set-PSFConfig -Module dbachecks -Name policy.database.status.excludeoffline -Value @() -Initialize -Description "Database names that we expect to be offline"
+Set-PSFConfig -Module dbachecks -Name policy.database.status.excluderestoring -Value @() -Initialize -Description "Database names that we expect to be restoring"
 
 # Policy for Ola Hallengren Maintenance Solution
 Set-PSFConfig -Module dbachecks -name policy.ola.installed -Validation bool -Value $true -Initialize -Description "Checks to see if Ola Hallengren solution is installed"

--- a/tests/Unit.Tests.ps1
+++ b/tests/Unit.Tests.ps1
@@ -41,7 +41,7 @@ Describe "Checking that each dbachecks Pester test is correctly formatted for Po
                 }
                 # a simple test for no esses apart from statistics and Access!!
                 if ($null -ne $PSItem.Tags) {
-                    $PSItem.Tags.Text.Split(',').Trim().Where{($PSItem -ne '$filename') -and ($PSItem -notlike '*statistics*') -and ($PSItem -notlike '*BackupPathAccess*') -and ($PSItem -notlike '*OlaJobs*') }.ForEach{
+                    $PSItem.Tags.Text.Split(',').Trim().Where{($PSItem -ne '$filename') -and ($PSItem -notlike '*statistics*') -and ($PSItem -notlike '*BackupPathAccess*') -and ($PSItem -notlike '*OlaJobs*') -and ($PSItem -notlike '*status*') }.ForEach{
                         It "$PSItem Should Be Singular" {
                             $PSItem.ToString().Endswith('s') | Should -BeFalse -Because 'Our coding standards say tags should be singular'
                         }

--- a/tests/checks/DatabaseChecks.Test.ps1
+++ b/tests/checks/DatabaseChecks.Test.ps1
@@ -1,7 +1,7 @@
 # load all of the assertion functions
 (Get-ChildItem $PSScriptRoot/../../internal/assertions/).ForEach{. $Psitem.FullName}
 
-Describe "Checking Instance.Tests.ps1 checks" -Tag UnitTest {
+Describe "Checking Database.Tests.ps1 checks" -Tag UnitTest {
     Context "Testing Database Max Dop" {
         ## Mock for Passing
         Mock Test-DbaMaxDop {
@@ -23,5 +23,224 @@ Describe "Checking Instance.Tests.ps1 checks" -Tag UnitTest {
                 {Assert-DatabaseMaxDop -MaxDop $PsItem -MaxDopValue 4} | Should -Throw -ExpectedMessage "Expected 4, because We expect the Database MaxDop Value 5 to be the specified value 4, but got '5'."
             }
         }
+    }
+
+    Context "Testing Database Status" {
+        #mock for passing
+        Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Pass when all databases are ok" {
+            Assert-DatabaseStatus Dummy
+        }
+        # Mock for readonly failing
+        Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $True;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Fail for a database that is readonly" {
+            { Assert-DatabaseStatus Dummy} | Should -Throw -ExpectedMessage "Expected 'True' to not be found in collection @(`$false, `$true), because We expect that there will be no Read-Only databases except for those specified, but it was found."
+        }
+        It "It Should Not Fail for a database that is readonly when it is excluded" {
+            Assert-DatabaseStatus -Instance Dummy -ExcludeReadOnly 'Dummy2' 
+        }
+        # Mock for offline failing
+        Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'Offline, AutoClosed';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Fail for a database that is offline" {
+            { Assert-DatabaseStatus Dummy} | Should -Throw -ExpectedMessage "Expected regular expression 'Offline' to not match 'Offline, AutoClosed', because We expect that there will be no offline databases except for those specified, but it did match."
+        }
+        It "It Should Not Fail for a database that is offline when it is excluded" {
+            Assert-DatabaseStatus Dummy -ExcludeOffline 'Dummy1'
+       }
+          # Mock for restoring failing
+          Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'Restoring';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Fail for a database that is restoring" {
+            { Assert-DatabaseStatus Dummy} | Should -Throw -ExpectedMessage "Expected regular expression 'Restoring' to not match 'Restoring', because We expect that there will be no databases in a restoring state except for those specified, but it did match."
+        }
+        It "It Should Not Fail for a database that is restoring when it is excluded" {
+            Assert-DatabaseStatus Dummy -ExcludeRestoring 'Dummy1'
+       }
+          # Mock for recovery failing
+          Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'Recovering';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Fail for a database that is Recovering" {
+            { Assert-DatabaseStatus Dummy} | Should -Throw -ExpectedMessage "Expected regular expression 'Recover' to not match 'Recovering', because We expect that there will be no databases going through the recovery process or in a recovery pending state, but it did match."
+        }
+          # Mock for recovery pending failing
+          Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'RecoveryPending';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Fail for a database that is Recovery pending" {
+            { Assert-DatabaseStatus Dummy} | Should -Throw -ExpectedMessage "Expected regular expression 'Recover' to not match 'RecoveryPending', because We expect that there will be no databases going through the recovery process or in a recovery pending state, but it did match."
+        }
+          # Mock for autoclosed failing
+          Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'AutoClosed';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Fail for a database that is AutoClosed" {
+            { Assert-DatabaseStatus Dummy} | Should -Throw -ExpectedMessage "Expected regular expression 'AutoClosed' to not match 'AutoClosed', because We expect that there will be no databases that have been auto closed, but it did match."
+        }
+        
+          # Mock for EmergencyMode failing
+          Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'EmergencyMode';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Fail for a database that is EmergencyMode" {
+            { Assert-DatabaseStatus Dummy} | Should -Throw -ExpectedMessage "Expected regular expression 'Emergency' to not match 'EmergencyMode', because We expect that there will be no databases in EmergencyMode, but it did match."
+        }
+        
+          # Mock for Suspect failing
+          Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'Suspect';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Fail for a database that is Suspect" {
+            { Assert-DatabaseStatus Dummy} | Should -Throw -ExpectedMessage "Expected regular expression 'Suspect' to not match 'Suspect', because We expect that there will be no databases in a Suspect state, but it did match."
+        }
+        
+          # Mock for Standby failing
+          Mock Connect-DbaInstance {
+            @{
+                Databases = @(
+                    @{
+                        Name     = 'Dummy1';
+                        ReadOnly = $False;
+                        Status   = 'Standby';
+                    },
+                    @{
+                        Name     = 'Dummy2';
+                        ReadOnly = $False;
+                        Status   = 'Normal';
+                    }
+                );
+            }
+        }
+        It "It Should Fail for a database that is Standby" {
+            { Assert-DatabaseStatus Dummy} | Should -Throw -ExpectedMessage "Expected regular expression 'Standby' to not match 'Standby', because We expect that there will be no databases in Standby, but it did match."
+        }
+    
+       It "Should Not Fail for databases that are excluded" {
+        Assert-DatabaseStatus Dummy -Excludedbs 'Dummy1'
+       }
     }
 }


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

Tests that there are no databases on an instance that are in a state of AutoClose, Offline, ReadOnly, Restoring, Recovery, Recovery Pending, EmergencyMode, Suspect or StandBy. Databases that are in ReadOnly,Offline and Restoring mode can be specified (default none)

Uses an assertion file and has unit tests for the assertion function