### PR TITLE
Skipping Ad Hoc Workload check for SQL < 2008

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -66,7 +66,7 @@ Describe "TempDB Configuration" -Tags TempDbConfiguration, $filename {
 Describe "Ad Hoc Workload Optimization" -Tags AdHocWorkload, $filename {
     @(Get-Instance).ForEach{
         Context "Testing Ad Hoc Workload Optimization on $psitem" {
-            It "$psitem Should Be Optimised for Ad Hoc workloads" {
+            It "$psitem Should Be Optimised for Ad Hoc workloads" -Skip:((Get-Version -SQLInstance $psitem) -lt 10) {
                 @(Test-DbaOptimizeForAdHoc -SqlInstance $psitem).ForEach{
                     $psitem.CurrentOptimizeAdHoc | Should -Be $psitem.RecommendedOptimizeAdHoc
                 }


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

- [x] There are 0 failing Pester tests

## Changes this PR brings

This feature was introduced in SQL 2008, so anything under that will be a false flag as we can't enable the feature for those. Use the same version check as `Default Backup Compression` does.