### PR TITLE
ExcludedDatabases didn't include dbs passed in on -ExcludeDatabase param

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -2,6 +2,7 @@ $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 . $PSScriptRoot/../internal/assertions/Database.Assertions.ps1 
 
 $ExcludedDatabases = Get-DbcConfigValue command.invokedbccheck.excludedatabases
+$ExcludedDatabases += $ExcludeDatabase
 $NotContactable = Get-PSFConfig -Module dbachecks -Name global.notcontactable 
 
 @(Get-Instance).ForEach{


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

- [X] There are 0 failing Pester tests

## Changes this PR brings
- Adds the contents of the ExcludeDatabase parameter to the ExcludedDatabases variable that is used thoughout the checks.