### PR TITLE
Build ref update

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -259,7 +259,7 @@ $NotContactable = Get-PSFConfig -Module dbachecks -Name global.notcontactable
 
     Describe "Supported Build" -Tags SupportedBuild, DISA, $filename {
         $BuildWarning = Get-DbcConfigValue policy.build.warningwindow
-        $BuildBehind = Get-DbcConfigValue policy.build.behindvalue
+        $BuildBehind = Get-DbcConfigValue policy.build.behind
         if ($NotContactable -contains $psitem) {
             Context "Checking that build is still supportedby Microsoft for $psitem" {
                 It "Can't Connect to $Psitem" {
@@ -283,7 +283,7 @@ $NotContactable = Get-PSFConfig -Module dbachecks -Name global.notcontactable
                     $results.SupportedUntil  | Should -BeGreaterThan (Get-Date).AddMonths($BuildWarning) -Because "this build will soon be unsupported by Microsoft"
                 }
                 It "$($results.Build) on $psitem is at most $BuildBehind behind the latest build" -Skip:$Skip {
-				            $results.Compliant | Should -Be $true -Because "this build should not be behind the required build"
+                    $results.Compliant | Should -Be $true -Because "this build should not be behind the required build"
           }
       }
 

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -171,24 +171,24 @@ Describe "SQL Memory Dumps" -Tags MemoryDump, $filename {
 
 Describe "Supported Build" -Tags SupportedBuild, DISA, $filename {
     $BuildWarning = Get-DbcConfigValue policy.build.warningwindow
-	$BehindValue = Get-DbcConfigValue policy.build.behindvalue
+	$BuildBehind = Get-DbcConfigValue policy.build.behindvalue
     @(Get-Instance).ForEach{
         Context "Checking that build is still supportedby Microsoft for $psitem" {
-			if ($BehindValue -eq $null) { 
+			if ($BuildBehind -eq $null) { 
 				$results = Test-DbaSQLBuild -SqlInstance $psitem -Latest 
 				$Skip = $true
 			}
 			else { 
-				$results = Test-DbaSQLBuild -SqlInstance $psitem -MaxBehind $BehindValue
+				$results = Test-DbaSQLBuild -SqlInstance $psitem -MaxBehind $BuildBehind
 			}
             It "$($results.Build) on $psitem is still supported" {
-                $results.SupportedUntil | Should -BeGreaterThan (Get-Date) -Because "This build is now unsupported by Microsoft"
+                $results.SupportedUntil | Should -BeGreaterThan (Get-Date) -Because "this build is now unsupported by Microsoft"
             }
             It "$($results.Build) on $psitem is supported for more than $BuildWarning Months" {
-                $results.SupportedUntil | Should -BeGreaterThan (Get-Date).AddMonths($BuildWarning) -Because "This build will soon be unsupported by Microsoft"
+                $results.SupportedUntil | Should -BeGreaterThan (Get-Date).AddMonths($BuildWarning) -Because "this build will soon be unsupported by Microsoft"
             }
-			It "$($results.Build) on $psitem is at most $BehindValue behind the latest build" -Skip:$Skip {
-				$results.Compliant | Should -Be $true -Because " this build should not be behind the required build"
+			It "$($results.Build) on $psitem is at most $BuildBehind behind the latest build" -Skip:$Skip {
+				$results.Compliant | Should -Be $true -Because "this build should not be behind the required build"
 			
 			}
         }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -171,15 +171,26 @@ Describe "SQL Memory Dumps" -Tags MemoryDump, $filename {
 
 Describe "Supported Build" -Tags SupportedBuild, DISA, $filename {
     $BuildWarning = Get-DbcConfigValue policy.build.warningwindow
+	$BehindValue = Get-DbcConfigValue policy.build.behindvalue
     @(Get-Instance).ForEach{
         Context "Checking that build is still supportedby Microsoft for $psitem" {
-            $results = Get-DbaSqlBuildReference -SqlInstance $psitem
+			if ($BehindValue -eq $null) { 
+				$results = Test-DbaSQLBuild -SqlInstance $psitem -Latest 
+				$Skip = $true
+			}
+			else { 
+				$results = Test-DbaSQLBuild -SqlInstance $psitem -MaxBehind $BehindValue
+			}
             It "$($results.Build) on $psitem is still supported" {
-                $results.SupportedUntil  | Should -BeGreaterThan (Get-Date) -Because 'This build is now unsupported by Microsoft'
+                $results.SupportedUntil | Should -BeGreaterThan (Get-Date) -Because "This build is now unsupported by Microsoft"
             }
             It "$($results.Build) on $psitem is supported for more than $BuildWarning Months" {
-                $results.SupportedUntil  | Should -BeGreaterThan (Get-Date).AddMonths($BuildWarning) -Because 'This build will soon be unsupported by Microsoft'
+                $results.SupportedUntil | Should -BeGreaterThan (Get-Date).AddMonths($BuildWarning) -Because "This build will soon be unsupported by Microsoft"
             }
+			It "$($results.Build) on $psitem is at most $BehindValue behind the latest build" -Skip:$Skip {
+				$results.Compliant | Should -Be $true -Because " this build should not be behind the required build"
+			
+			}
         }
     }
 }

--- a/dbachecks.psd1
+++ b/dbachecks.psd1
@@ -11,7 +11,7 @@
     RootModule             = 'dbachecks.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '1.1.138'
+    ModuleVersion          = '1.1.139'
 
     # ID used to uniquely identify this module
     GUID                   = '578c5d98-50c8-43a8-bdbb-d7159028d7ac'

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -25,3 +25,24 @@ function Assert-TempDBSize {
 
     @((Get-DbaDatabaseFile -SqlInstance $Instance -Database tempdb).Where{$_.Type -eq 0}.Size.Megabyte |Select-Object -Unique).Count | Should -Be 1 -Because "We want all the tempdb data files to be the same size - See https://blogs.sentryone.com/aaronbertrand/sql-server-2016-tempdb-fixes/ and https://www.brentozar.com/blitz/tempdb-data-files/ for more information"
 }
+
+function Assert-InstanceSupportedBuild {
+	Param(
+        [string]$Instance,
+		[int]$BuildWarning,
+        [string]$BuildBehind,
+        $Date
+    )
+    #If $BuildBehind check against SP/CU parameter to determine validity of the build in addition to support dates
+ 	if ($BuildBehind) {
+		$results = Test-DbaSQLBuild -SqlInstance $Instance -MaxBehind $BuildBehind
+		$results.SupportedUntil | Should -BeGreaterThan $Date -Because "this build is now unsupported by Microsoft"
+		$results.SupportedUntil | Should -BeGreaterThan ($Date).AddMonths($BuildWarning) -Because "this build will soon be unsupported by Microsoft"
+		$results.Compliant | Should -Be $true -Because "this build should not be behind the required build"
+	#If no $BuildBehind only check against support dates
+     }	else {
+        $SupportedUntil = (Test-DbaSQLBuild -SqlInstance $Instance -Latest).SupportedUntil 
+		$SupportedUntil | Should -BeGreaterThan $Date -Because "this build is now unsupported by Microsoft"
+        $SupportedUntil | Should -BeGreaterThan $(Get-Date).AddMonths(6) -Because "this build will soon be unsupported by Microsoft"
+    }
+} 

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -19,3 +19,25 @@ function Assert-BackupCompression {
     Param($Instance,$defaultbackupcompression)
     (Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'DefaultBackupCompression').ConfiguredValue -eq 1 | Should -Be $defaultbackupcompression -Because 'The default backup compression should be set correctly'
 }
+
+function Assert-InstanceSupportedBuild {
+	Param(
+        [string]$Instance,
+		[int]$BuildWarning,
+		[string]$BehindValue
+	)
+
+	if ($BehindValue) {
+        #If $BehindValue check against SP/CU parameter to determine validity of the build in addition to support dates
+		$results = Test-DbaSQLBuild -SqlInstance $Instance -MaxBehind $BehindValue
+		$results.SupportedUntil | Should -BeGreaterThan (Get-Date) -Because "this build is now unsupported by Microsoft"
+		$results.SupportedUntil | Should -BeGreaterThan (Get-Date).AddMonths($BuildWarning) -Because "this build will soon be unsupported by Microsoft"
+		$results.Compliant | Should -Be $true -Because "this build should not be behind the required build"
+		
+	}	else {
+		#If no $BehindValue only check against support dates
+        $SupportedUntil = (Test-DbaSQLBuild -SqlInstance $Instance -Latest).SupportedUntil 
+		$SupportedUntil | Should -BeGreaterThan (Get-Date) -Because "this build is now unsupported by Microsoft"
+		$SupportedUntil | Should -BeGreaterThan (Get-Date).AddMonths($BuildWarning) -Because "this build will soon be unsupported by Microsoft"
+    }
+}

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -177,6 +177,7 @@ Set-PSFConfig -Module dbachecks -Name policy.whoisactive.database -Value "master
 
 #Build
 Set-PSFConfig -Module dbachecks -Name policy.build.warningwindow -Value 6 -Initialize -Description "The number of months prior to a build being unsupported that you want warning about"
+Set-PSFConfig -Module dbachecks -Name policy.build.behindvalue -Value $null -Initialize -Description "The max number of service packs and/or cumulative updates a build can be behind by"
 
 # The frequency of the Ola Hallengrens User Full backups
 # See https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.agent.jobschedule.frequencyinterval.aspx

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -177,7 +177,7 @@ Set-PSFConfig -Module dbachecks -Name policy.whoisactive.database -Value "master
 
 #Build
 Set-PSFConfig -Module dbachecks -Name policy.build.warningwindow -Value 6 -Initialize -Description "The number of months prior to a build being unsupported that you want warning about"
-Set-PSFConfig -Module dbachecks -Name policy.build.behindvalue -Value $null -Initialize -Description "The max number of service packs and/or cumulative updates a build can be behind by"
+Set-PSFConfig -Module dbachecks -Name policy.build.behind -Value $null -Initialize -Description "The max number of service packs and/or cumulative updates a build can be behind by (ex. 1SP or 3CU)"
 
 # The frequency of the Ola Hallengrens User Full backups
 # See https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.agent.jobschedule.frequencyinterval.aspx

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -87,4 +87,23 @@ Describe "Checking Instance.Tests.ps1 checks" -Tag UnitTest {
                 Assert-MockCalled @assertMockParams
             }
     }
+    Context "Checking Supported Build" {
+        $TestCases = @{"MaxBehind" = "1SP"}, @{"MaxBehind" = "1CU"}
+        #if MaxBehind it should pass if build is >= SP/CU behind specified
+        It "Passes check correctly with a specified value <MaxBehind>" -TestCases $TestCases {
+            Param($MaxBehind)
+            #Mock to pass 
+            Mock Test-DbaSqlBuild {@{"SPLevel" = "{SP4, LATEST}"; "CULevel" = ""}}
+            {Assert-InstanceSupportedBuild -Instance 'Dummy' -MaxBehind $MaxBehind} 
+        }
+        $TestCases = @{"MaxBehind" = "1SP"; "BuildWarning" = 6}, @{"MaxBehind" = "1CU"; "BuildWarning" = 6}
+        #if MaxBehind it should fail if build is <= SP/CU behind specified
+        It "Failed check correctly with a specified value <MaxBehind>" -TestCases $TestCases {
+            Param($MaxBehind)
+            #Mock to fail 
+            Mock Test-DbaSqlBuild {@{"Compliant" = $false; "SupportedUntil" = (Get-Date).AddMonths(-1)}}
+            {Assert-InstanceSupportedBuild -Instance 'Dummy' -Latest} | Should -Throw -ExpectedMessage "Expected $(Get-Date) to be greater than the actual value, because this build is now unsupported by Microsoft, but got $(Get-Date).AddMonths(-1)"
+        }
+
+    }
 }


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

[x] There are 0 failing Pester tests

## Changes this PR brings

For issue #499, this changes the build support date check to use the Test-DbaSqlBuild function instead and also introduces the option to use the `-MaxBehind` parameter in conjunction with the support date window.
