### PR TITLE
Fixed Error when using -Credential, -SqlCredential, Fixed wrong location

### DIFF
--- a/functions/Invoke-DbcCheck.ps1
+++ b/functions/Invoke-DbcCheck.ps1
@@ -234,6 +234,7 @@
         
         if ($SqlCredential) {
             if ($PSDefaultParameterValues) {
+                $PSDefaultParameterValues.Remove('*:SqlCredential')
                 $newvalue = $PSDefaultParameterValues += @{ '*:SqlCredential' = $SqlCredential }
                 Set-Variable -Scope 0 -Name PSDefaultParameterValues -Value $newvalue
             }
@@ -249,6 +250,7 @@
         
         if ($Credential) {
             if ($PSDefaultParameterValues) {
+                $PSDefaultParameterValues.Remove('*Dba*:Credential')
                 $newvalue = $PSDefaultParameterValues += @{ '*Dba*:Credential' = $Credential }
                 Set-Variable -Scope 0 -Name PSDefaultParameterValues -Value $newvalue
             }
@@ -342,6 +344,7 @@
                     ## remove any previous entries ready for this run
                     Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value @()
                     Invoke-Pester @PSBoundParameters
+                    Pop-Location
                 }
             }
             $finishedAllTheChecks = $true
@@ -352,8 +355,8 @@
         finally {
             if (!($finishedAllTheChecks)) {
                 Write-PSFMessage -Level Warning -Message "Execution was cancelled!"
+                Pop-Location
             }
-            Pop-Location
         }
     }
 }


### PR DESCRIPTION
# A New PR

## Please confirm you have 0 failing Pester Tests

[x] There are 0 failing Pester tests

## Changes this PR brings

Fixed Error:
- If PSDefaultParameterValues has already been initialized with *Dba*:Credential or *:SqlCredential, overwriting it with -Credential or -SqlCredential will fail. This happens if you set the default value 'app.sqlcredential' in your config for example and call Invoke-DbcCheck with -SqlCredential.

Fixed wrong location:
- If you use more than one dbachecks repo, as we do you need to call Pop-Location as many times as Push-Location or you will end up in one of your checks directory after Invoke-DbcCheck has finished. This can be very annoying when testing manually.