### PR TITLE
New check - Two Digit Year Cutoff

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -547,6 +547,24 @@ $NotContactable = Get-PSFConfig -Module dbachecks -Name global.notcontactable
 			}
 		}
 	}
+
+	Describe "Two Digit Year Cutoff" -Tags TwoDigitYearCutoff, $filename {
+		$twodigityearcutoff = Get-DbcConfigValue policy.twodigityearcutoff
+		if ($NotContactable -contains $psitem) {
+			Context "Testing Two Digit Year Cutoff on $psitem" {
+				It "Can't Connect to $Psitem" {
+					$false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
+				}
+			}
+		}
+		else {
+			Context "Testing Two Digit Year Cutoff on $psitem" {
+				It "Two Digit Year Cutoff is set to $twodigityearcutoff on $psitem" {
+					(Get-DbaSpConfigure -SqlInstance $psitem -ConfigName 'TwoDigitYearCutoff').ConfiguredValue | Should -Be $twodigityearcutoff -Because 'This is the value that you have chosen for Two Digit Year Cutoff configuration'
+				}
+			}
+		}
+	}
 }
 
 Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, $filename {

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -560,7 +560,7 @@ $NotContactable = Get-PSFConfig -Module dbachecks -Name global.notcontactable
 		else {
 			Context "Testing Two Digit Year Cutoff on $psitem" {
 				It "Two Digit Year Cutoff is set to $twodigityearcutoff on $psitem" {
-					(Get-DbaSpConfigure -SqlInstance $psitem -ConfigName 'TwoDigitYearCutoff').ConfiguredValue | Should -Be $twodigityearcutoff -Because 'This is the value that you have chosen for Two Digit Year Cutoff configuration'
+					Assert-TwoDigitYearCutoff -Instance $psitem -TwoDigitYearCutoff $twodigityearcutoff
 				}
 			}
 		}

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -56,5 +56,5 @@ function Assert-TwoDigitYearCutoff {
         [string]$Instance,
         [int]$TwoDigitYearCutoff
     )
-    (Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'TwoDigitYearCutoff').ConfiguredValue | Should -Be $defaulTwoDigitYearCutofftbackupcompression -Because 'This is the value that you have chosen for Two Digit Year Cutoff configuration'
+    (Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'TwoDigitYearCutoff').ConfiguredValue | Should -Be $TwoDigitYearCutoff -Because 'This is the value that you have chosen for Two Digit Year Cutoff configuration'
 }

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -51,3 +51,10 @@ function Assert-InstanceSupportedBuild {
         $Results.SupportedUntil | Should -BeGreaterThan $expected -Because "this build $($results.Build) will be unsupported by Microsoft on $SupportedUntil which is less than $BuildWarning months away"
     }
 }
+function Assert-TwoDigitYearCutoff {
+    Param(
+        [string]$Instance,
+        [int]$TwoDigitYearCutoff
+    )
+    (Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'TwoDigitYearCutoff').ConfiguredValue | Should -Be $defaulTwoDigitYearCutofftbackupcompression -Because 'This is the value that you have chosen for Two Digit Year Cutoff configuration'
+}

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -28,7 +28,6 @@ function Assert-TempDBSize {
 
 function Assert-InstanceSupportedBuild {
 	Param(
-        
         [string]$Instance,
 		[int]$BuildWarning,
         [string]$BuildBehind,

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -196,6 +196,10 @@
         "Description": "Tests that the Dedicated Administrator Connection configuration setting matches the specified value (default true)"
     },
     {
+        "UniqueTag": "TwoDigitYearCutoff",
+        "Description": "Tests that the 'Two Digit Year Cutoff' configuration setting matches the specified value (default 2049)"
+    },
+    {
         "UniqueTag": "NetworkLatency",
         "Description": "Tests that the Network Latency is less than the specified (default 40) ms"
     },
@@ -367,4 +371,4 @@
         "UniqueTag": "DatabaseExists",
         "Description": "Tests that the databases are specified are on the instance (Note - Does not check if they are avaiable - Use DatabaseStatus for that))"
     }
- ] 
+ ]

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -82,6 +82,9 @@ Set-PSFConfig -Module dbachecks -Name policy.dacallowed -Validation bool -Value 
 #OLE Automation
 Set-PSFConfig -Module dbachecks -Name policy.oleautomation -Validation bool -Value $false -Initialize -Description "OLE Automation should be enabled `$true or disabled `$false"
 
+#Two Digit Year Cutoff
+Set-PSFConfig -Module dbachecks -Name policy.twodigityearcutoff -Value 2049 -Initialize -Description "The value for 'Two Digit Year Cutoff' configuration. Default is 2049. "
+
 #Connectivity
 Set-PSFConfig -Module dbachecks -Name policy.connection.authscheme  -Value "Kerberos" -Initialize -Description "Auth requirement (Kerberos, NTLM, etc)"
 Set-PSFConfig -Module dbachecks -Name policy.connection.pingmaxms -Value 10 -Initialize -Description "Maximum response time in ms"


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

[x] There are 0 failing Pester tests

## Changes this PR brings
 - Added New Check for `Two Digit Year Cutoff` configuration
 - Added `policy.twodigityearcutoff` with default 2049 (SQL Server default value)

Based on my blog post [Don’t cutoff yourself with dates in T-SQL – Did you know…](https://claudioessilva.eu/2018/09/04/dont-cutoff-yourself-when-dealing-with-dates-in-t-sql-did-you-know/) and also because @shaneis (thanks man :+ ) remembered me that this was not part of dbachecks 😄 