### PR TITLE
Adding it blocks to the test file for Supported Build Checks

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -220,7 +220,6 @@ $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 		}
 	}
 
-
 	Describe "SQL and Windows names match" -Tags ServerNameMatch, $filename {
 		if ($NotContactable -contains $psitem) {
 			Context "Testing instance name matches Windows name for $psitem" {
@@ -262,6 +261,7 @@ $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 		$BuildBehind = Get-DbcConfigValue policy.build.behind
 		$Date = Get-Date 
 
+
 		if ($NotContactable -contains $psitem) {
 			Context "Checking that build is still supportedby Microsoft for $psitem" {
 				It "Can't Connect to $Psitem" {
@@ -271,7 +271,19 @@ $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 		}
 		else {
 			Context "Checking that build is still supportedby Microsoft for $psitem" {
-				Assert-InstanceSupportedBuild -Instance $psitem -BuildWarning $BuildWarning -BuildBehind $BuildBehind -Date $Date
+				if ($BuildBehind) {
+					It "$psitem is not behind the latest build by more than $BuildBehind" {
+						Assert-InstanceSupportedBuild -Instance $psitem -BuildBehind $BuildBehind -Date $Date
+					}
+				}
+				It "$Instance's build is supported by Microsoft" {
+					Assert-InstanceSupportedBuild -Instance $psitem -Date $Date
+				}
+				It "$Instance's build is supported by Microsoft within the warning window of $BuildWarning months" {
+					Assert-InstanceSupportedBuild -Instance $psitem -BuildWarning $BuildWarning -Date $Date
+				}
+
+
 	  		}
 		}
 	}

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -16,7 +16,7 @@ function Assert-InstanceMaxDop {
 }
 
 function Assert-BackupCompression {
-    Param($Instance,$defaultbackupcompression)
+    Param($Instance, $defaultbackupcompression)
     (Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'DefaultBackupCompression').ConfiguredValue -eq 1 | Should -Be $defaultbackupcompression -Because 'The default backup compression should be set correctly'
 }
 
@@ -27,27 +27,33 @@ function Assert-TempDBSize {
 }
 
 function Assert-InstanceSupportedBuild {
-	Param(
+    Param(
         [string]$Instance,
-		[int]$BuildWarning,
+        [int]$BuildWarning,
         [string]$BuildBehind,
         [DateTime]$Date
     )
-    #If $BuildBehind check against SP/CU parameter to determine validity of the build in addition to support dates
- 	if ($BuildBehind) {
+    #If $BuildBehind check against SP/CU parameter to determine validity of the build
+    if ($BuildBehind) {
         $results = Test-DbaSQLBuild -SqlInstance $Instance -MaxBehind $BuildBehind
-        $SupportedUntil = Get-Date $results.SupportedUntil -Format O
-        $expected = ($Date).AddMonths($BuildWarning)
-		$results.SupportedUntil | Should -BeGreaterThan $Date -Because "this build $($Results.Build) is now unsupported by Microsoft"
-		$results.SupportedUntil | Should -BeGreaterThan $expected -Because "this build $($results.Build) will be unsupported by Microsoft on $SupportedUntil which is less than $BuildWarning months away"
-		$results.Compliant | Should -Be $true -Because "this build $($Results.Build) should not be behind the required build"
-	#If no $BuildBehind only check against support dates
-     }	else {
+        $Compliant = $results.Compliant
+        $Build = $results.build
+        $Compliant | Should -Be $true -Because "this build $Build should not be behind the required build"
+        #If no $BuildBehind only check against support dates
+    }	
+    else {
         $Results = Test-DbaSQLBuild -SqlInstance $Instance -Latest
-        $SupportedUntil = Get-Date $results.SupportedUntil -Format O
-        $expected = ($Date).AddMonths($BuildWarning)
-		$Results.SupportedUntil | Should -BeGreaterThan $Date -Because "this build $($Results.Build) is now unsupported by Microsoft"
-        $Results.SupportedUntil | Should -BeGreaterThan $expected -Because "this build $($results.Build) will be unsupported by Microsoft on $SupportedUntil which is less than $BuildWarning months away"
+        [DateTime]$SupportedUntil = Get-Date $results.SupportedUntil -Format O
+        $Build = $results.build
+        #If $BuildWarning, check for support date within the warning window
+        if ($BuildWarning) {
+            [DateTime]$expected = Get-Date ($Date).AddMonths($BuildWarning) -Format O
+            $SupportedUntil | Should -BeGreaterThan $expected -Because "this build $Build will be unsupported by Microsoft on $(Get-Date $SupportedUntil -Format O) which is less than $BuildWarning months away"
+        }
+        #If neither, check for Microsoft support date
+        else {
+            $SupportedUntil | Should -BeGreaterThan $Date -Because "this build $Build is now unsupported by Microsoft"
+        }
     }
 }
 

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -169,43 +169,43 @@ Describe "Checking Instance.Tests.ps1 checks" -Tag UnitTest {
 			Param($BuildBehind, $Date, $expected, $actual)
 			#Mock to fail
 			Mock Test-DbaSqlBuild {@{"SPLevel" = "{SP2}"; "CULevel" = "CU2"; "SPTarget" = "SP4"; "CUTarget" = "CU4"; "Compliant" = $false; "SupportedUntil" = $Date.AddMonths(1); "Build" = 42}}
-			{Assert-InstanceSupportedBuild -Instance 'Dummy' -BuildBehind $BuildBehind -Date $Date} | Should -Throw -ExpectedMessage "Expected `$$expected, because this build 42 should not be behind the required build, but got `$$actual"
+			{ Assert-InstanceSupportedBuild -Instance 'Dummy' -BuildBehind $BuildBehind -Date $Date} | Should -Throw -ExpectedMessage "Expected `$$expected, because this build 42 should not be behind the required build, but got `$$actual"
 		}
 		$TestCases = @{"Date" = $Date}
-		#if not BuildBehind it should pass if support dates are valid
+		#if neither BuildBehind nor BuildWarning it should pass if support dates are valid
 		It "Passed check correctly with a SupportedUntil date > today" -TestCases $TestCases {
 			Param($Date)
 			#Mock to pass
 			Mock Test-DbaSqlBuild {@{"SupportedUntil" = $Date.AddMonths(1)}}
-			{Assert-InstanceSupportedBuild -Instance 'Dummy' -Date $Date}
+			Assert-InstanceSupportedBuild -Instance 'Dummy' -Date $Date
 		}
-		$TestCases = @{"Date" = $Date; "BuildWarning" = 6}
-		#if not BuildBehind it should fail if support date is out of the support window
+		$TestCases = @{"Date" = $Date}
+		#if neither BuildBehind nor BuildWarning it should fail if support date is out of the support window
 		It "Failed check correctly with a SupportedUntil date < today" -TestCases $TestCases {
-			Param($Date, $BuildWarning)
+			Param($Date)
 			#Mock to fail
 			Mock Test-DbaSqlBuild {@{"SupportedUntil" = $Date.AddMonths(-1); "Build" = 42}}
 			$SupportedUntil = Get-Date $Date.AddMonths(-1) -Format O
 			$Date = Get-Date $Date -Format O
-			{Assert-InstanceSupportedBuild -Instance 'Dummy' -Date $Date -BuildWarning $BuildWarning } | Should -Throw -ExpectedMessage "Expected the actual value to be greater than $Date, because this build 42 is now unsupported by Microsoft, but got $SupportedUntil"
+			{ Assert-InstanceSupportedBuild -Instance 'Dummy' -Date $Date } | Should -Throw -ExpectedMessage "Expected the actual value to be greater than $Date, because this build 42 is now unsupported by Microsoft, but got $SupportedUntil"
 		}
 		$TestCases = @{"Date" = $Date; "BuildWarning" = 6}
-		#if not BuildBehind it should fail if support date is in the warning window
+		#if BuildWarning it should fail if support date is in the warning window
 		It "Passed check correctly with the BuildWarning window > today" -TestCases $TestCases {
 			Param($Date, $BuildWarning)
 			#Mock to pass
 			Mock Test-DbaSqlBuild {@{"SupportedUntil" = $Date.AddMonths(9); "Build" = 42}}
-			{Assert-InstanceSupportedBuild -Instance 'Dummy' -Date $Date -BuildWarning $BuildWarning }
+			{ Assert-InstanceSupportedBuild -Instance 'Dummy' -Date $Date -BuildWarning $BuildWarning }
 		}
 		$TestCases = @{"Date" = $Date; "BuildWarning" = 6}
-		#if not BuildBehind it should fail if support date is in the warning window
+		#if BuildWarning it should fail if support date is in the warning window
 		It "Failed check correctly with the BuildWarning window < today" -TestCases $TestCases {
 			Param($Date, $BuildWarning)
 			#Mock to fail
 			Mock Test-DbaSqlBuild {@{"SupportedUntil" = $Date.AddMonths(3); "Build" = 42}}
 			$SupportedUntil = Get-Date $Date.AddMonths(3) -Format O
 			$expected = Get-Date $Date.AddMonths($BuildWarning) -Format O
-			{Assert-InstanceSupportedBuild -Instance 'Dummy' -Date $Date -BuildWarning $BuildWarning } | Should -Throw -ExpectedMessage "Expected the actual value to be greater than $expected, because this build 42 will be unsupported by Microsoft on $SupportedUntil which is less than $BuildWarning months away, but got $SupportedUntil"
+			{ Assert-InstanceSupportedBuild -Instance 'Dummy' -Date $Date -BuildWarning $BuildWarning } | Should -Throw -ExpectedMessage "Expected the actual value to be greater than $expected, because this build 42 will be unsupported by Microsoft on $SupportedUntil which is less than $BuildWarning months away, but got $SupportedUntil"
 		}
 
 	}


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

[x] There are 0 failing Pester tests

![image](https://user-images.githubusercontent.com/16843041/45127288-94140580-b145-11e8-98c5-e0c254cf20d6.png)


## Changes this PR brings

Fixing the mess that was #538 and adding the `It` blocks correctly (I hope).