### PR TITLE
Corrected multiple typos

### DIFF
--- a/Test-Pester.XML
+++ b/Test-Pester.XML
@@ -283,7 +283,7 @@
               <test-suite type="TestFixture" name="Testing Assert-DiskAllocationUnit" executed="True" result="Success" success="True" time="0.0862" asserts="0" description="Testing Assert-DiskAllocationUnit">
                 <results>
                   <test-case description="Should pass when all SQLDisks are formatted with the 65536b (64kb) block allocation unit size" name="Checking ServerChecks.Tests.Testing Assert-DiskAllocationUnit.Should pass when all SQLDisks are formatted with the 65536b (64kb) block allocation unit size" time="0.067" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="should fail when any SQLDisks is formatted with a block allocation unit size that isnt 65536b (64KB)" name="Checking ServerChecks.Tests.Testing Assert-DiskAllocationUnit.should fail when any SQLDisks is formatted with a block allocation unit size that isnt 65536b (64KB)" time="0.0192" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Should fail when any SQLDisks is formatted with a block allocation unit size that isn't 65536b (64KB)" name="Checking ServerChecks.Tests.Testing Assert-DiskAllocationUnit.should fail when any SQLDisks is formatted with a block allocation unit size that isn't 65536b (64KB)" time="0.0192" asserts="0" success="True" result="Success" executed="True" />
                 </results>
               </test-suite>
               <test-suite type="TestFixture" name="Testing Get-AllServerInfo for Tags Server with a server that exists" executed="True" result="Success" success="True" time="0.5203" asserts="0" description="Testing Get-AllServerInfo for Tags Server with a server that exists">

--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -176,7 +176,7 @@ Describe "Failsafe Operator" -Tags FailsafeOperator, Operator, $filename {
                 Context "Testing failsafe operator exists on $psitem" {
                     $failsafeoperator = Get-DbcConfigValue agent.failsafeoperator
                     It "failsafe operator on $psitem exists" {
-                        (Connect-DbaInstance -SqlInstance $psitem).JobServer.AlertSystem.FailSafeOperator | Should -Be $failsafeoperator -Because 'The failsafe operator will ensure that any job failures will be notifed to someone if not set explicitly'
+                        (Connect-DbaInstance -SqlInstance $psitem).JobServer.AlertSystem.FailSafeOperator | Should -Be $failsafeoperator -Because 'The failsafe operator will ensure that any job failures will be notified to someone if not set explicitly'
                     }
                 }
             }

--- a/checks/HADR.Tests.ps1
+++ b/checks/HADR.Tests.ps1
@@ -90,7 +90,7 @@ foreach ($clustervm in $clusters) {
                     $psitem.State | Should -Be 'Online' -Because 'All of the cluster resources should be online'
                 }
             }
-            # Get teh resources where IP Address is owned by AG and group by AG
+            # Get the resources where IP Address is owned by AG and group by AG
             @($return.Resources.Where{$_.ResourceType -eq 'IP Address' -and $_.OwnerGroup -in $return.AGs} | Group-Object -Property OwnerGroup).ForEach{
                 It "One of the IP Addresses for Availability Group $($Psitem.Name) Should be online" {
                     $psitem.Group.Where{$_.State -eq 'Online'}.Count | Should -Be 1 -Because "There should be one IP Address online for Availability Group $($PSItem.Name)"

--- a/checks/MaintenanceSolution.Tests.ps1
+++ b/checks/MaintenanceSolution.Tests.ps1
@@ -335,7 +335,7 @@ Describe "Ola - $OutputFileJobName" -Tags OutputFileCleanup, OlaJobs, $filename 
             }
         }
 
-        Context "Checking the Output File Job Clenup Time on $psitem" {
+        Context "Checking the Output File Job Cleanup Time on $psitem" {
             $jobsteps = $job.JobSteps | Where-Object { $_.SubSystem -eq "CmdExec" -or $_.SubSystem -eq "TransactSql" }
             $days = [regex]::matches($jobsteps.Command, "\/d\s-(\d\d)").groups[1].value
 

--- a/docs/functions/Set-DbcConfig.md
+++ b/docs/functions/Set-DbcConfig.md
@@ -11,7 +11,7 @@ Set-DbcConfig [[-Name] <String>] [[-Value] <Object>] [[-Handler] <ScriptBlock>] 
 ```
 
 ## DESCRIPTION
-Changes configuration values which enable each check to have specific threshholds
+Changes configuration values which enable each check to have specific thresholds
 
 ## EXAMPLES
 

--- a/functions/Invoke-DbcCheck.ps1
+++ b/functions/Invoke-DbcCheck.ps1
@@ -334,7 +334,7 @@ function Invoke-DbcCheck {
             Write-PSFMessage -Level Warning -Message "$ExcludedDatabases databases will be skipped for all checks"
         }
 
-        # Then we'll need a generic param passer that doesnt require global params 
+        # Then we'll need a generic param passer that doesn't require global params 
         # cuz global params are hard
 
         $finishedAllTheChecks = $false

--- a/functions/Reset-DbcConfig.ps1
+++ b/functions/Reset-DbcConfig.ps1
@@ -38,7 +38,7 @@ function Reset-DbcConfig {
             $resolvedName = (Get-DbcConfig).Name
         }
         elseif ($Name -match '\*') {
-            # whildcard is used, get only the matching settings
+            # wildcard is used, get only the matching settings
             $resolvedName = (Get-DbcConfig).Name | Where-Object { $psitem -like $Name }
         }
         else { 
@@ -60,7 +60,7 @@ function Reset-DbcConfig {
         # set up everything that is now missing back to the default values
         Invoke-ConfigurationScript
 
-        # desplay the new values
+        # display the new values
         @($resolvedName).ForEach{
             Get-DbcConfig -Name $psitem 
         }

--- a/functions/Set-DbcConfig.ps1
+++ b/functions/Set-DbcConfig.ps1
@@ -3,7 +3,7 @@
 Sets configuration values for specific checks.
 
 .DESCRIPTION
-Changes configuration values which enable each check to have specific threshholds
+Changes configuration values which enable each check to have specific thresholds
 
 .PARAMETER Name
 Name of the configuration entry.

--- a/internal/assertions/Server.Assertions.ps1
+++ b/internal/assertions/Server.Assertions.ps1
@@ -71,12 +71,12 @@ function Get-AllServerInfo {
                         }
                     }
                     else {
-                        $PowerPlan = 'An Error occured'
+                        $PowerPlan = 'An Error occurred'
                     }
                 }
             }
             else {
-                $PowerPlan = 'An Error occured'
+                $PowerPlan = 'An Error occurred'
             }
         }
         {$Tags -contains 'SPN'} {
@@ -96,7 +96,7 @@ function Get-AllServerInfo {
                             $SPNs = [PSCustomObject]@{
                                 RequiredSPN            = 'Dont know the SPN'
                                 InstanceServiceAccount = 'Dont know the Account'
-                                Error                  = 'An Error Occured'
+                                Error                  = 'An Error occurred'
                             }
                         }
                     }
@@ -105,7 +105,7 @@ function Get-AllServerInfo {
                     $SPNs = [PSCustomObject]@{
                         RequiredSPN            = 'Dont know the SPN'
                         InstanceServiceAccount = 'Dont know the Account'
-                        Error                  = 'An Error Occured'
+                        Error                  = 'An Error occurred'
                     }
                 }
             }
@@ -113,7 +113,7 @@ function Get-AllServerInfo {
                 $SPNs = [PSCustomObject]@{
                     RequiredSPN            = 'Dont know the SPN'
                     InstanceServiceAccount = 'Dont know the Account'
-                    Error                  = 'An Error Occured'
+                    Error                  = 'An Error occurred'
                 }
             }
         }
@@ -137,7 +137,7 @@ function Get-AllServerInfo {
                         $DiskSpace = [PSCustomObject]@{
                             Name         = 'Do not know the Name'
                             PercentFree  = -1
-                            ComputerName = 'An Error occured ' + $ComputerName
+                            ComputerName = 'An Error occurred ' + $ComputerName
                         } 
                     }
                 }
@@ -146,7 +146,7 @@ function Get-AllServerInfo {
                 $DiskSpace = [PSCustomObject]@{
                     Name         = 'Do not know the Name'
                     PercentFree  = -1
-                    ComputerName = 'An Error occured ' + $ComputerName
+                    ComputerName = 'An Error occurred ' + $ComputerName
                 } 
             }
         }

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -329,7 +329,7 @@
     },
     {
         "UniqueTag": "InstanceConnection",
-        "Description": "Tests that a SQL query can be run, that the specified authentication scheme (default kerboros) is being used, that the host responds to one ping and that the host supports PS Remoting"
+        "Description": "Tests that a SQL query can be run, that the specified authentication scheme (default kerberos) is being used, that the host responds to one ping and that the host supports PS Remoting"
     },
     {
         "UniqueTag": "SPN",
@@ -369,7 +369,7 @@
     },
     {
         "UniqueTag": "DatabaseExists",
-        "Description": "Tests that the databases are specified are on the instance (Note - Does not check if they are avaiable - Use DatabaseStatus for that))"
+        "Description": "Tests that the databases are specified are on the instance (Note - Does not check if they are available - Use DatabaseStatus for that))"
     },
     {
         "UniqueTag": "TraceFlagsExpected",

--- a/internal/configurations/ReleaseNotes.txt
+++ b/internal/configurations/ReleaseNotes.txt
@@ -39,13 +39,13 @@ Improved error handling for HADR checks
 
 ## Date 28/08/2018
 Added MaxBehind to SupportedBuild Tests - Thank you @LowlyDBA
-Ensured the Database paramter checks only the specified Databases - Thank you @jpomfret
+Ensured the Database parameter checks only the specified Databases - Thank you @jpomfret
 Updated Set-DbcConifg to allow Append to append arrays to arrays closes #535
 Altered json filename creation to avoid max characters error
 Altered PowerBi to display information correctly with filename changes
 
 ## Date 24/08/2017
-Fixed Error with using Credential and stopped changing path when runnign checks from custom repos - Thank you @sammyxx
+Fixed Error with using Credential and stopped changing path when running checks from custom repos - Thank you @sammyxx
 
 ## Date 23/08/2017
 Update to the help message for clusters by @LowlyDBA
@@ -87,7 +87,7 @@ Fixed offline install bug #484
 
 Updated Required Module versions - Thank you @cl
 Updated Agent Checks to fail a test on no connection rather than throw all the PowerShell errors - Thanks @sqldbawithbeard
-Updated HADR Checks for PS4 compatability Issue #513
+Updated HADR Checks for PS4 compatibility Issue #513
 
 ## Date 28/06/2018
 

--- a/internal/functions/New-Json.ps1
+++ b/internal/functions/New-Json.ps1
@@ -49,7 +49,7 @@ function New-Json {
                 $type = "ComputerName"
             }
             elseif ($Describe.Parent -match "Get-ClusterObject") {
-                $Type = "ClusteNode"
+                $Type = "ClusterNode"
             }
             else {
                 #Choose the type from the new way from inside the foreach

--- a/tests/checks/DatabaseChecks.Tests.ps1
+++ b/tests/checks/DatabaseChecks.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Checking Database.Assertions.ps1 assertions" -Tag UnitTest, Assertions
             (Get-Command Get-Database).Parameters['ExcludedDbs'] | Should -Not -BeNullOrEmpty -Because "We need to pass in the Excluded Databases - Don't forget that the ExcludedDatabases parameter is set by default so dont use that"
         }
         It "Should have a Requiredinfo parameter" {
-            (Get-Command Get-Database).Parameters['Requiredinfo'] | Should -Not -BeNullOrEmpty -Because "We want to be able to choose the infomration we return"
+            (Get-Command Get-Database).Parameters['Requiredinfo'] | Should -Not -BeNullOrEmpty -Because "We want to be able to choose the information we return"
         }
         It "Should have a Exclusions parameter" {
             (Get-Command Get-Database).Parameters['Exclusions'] | Should -Not -BeNullOrEmpty -Because "We need to be able to excluded databases for various reasons like readonly etc"
@@ -387,7 +387,7 @@ Describe "Checking Database.Assertions.ps1 assertions" -Tag UnitTest, Assertions
             }
         }
 
-        It "Should Fail when the database doesnot exist" {
+        It "Should Fail when the database does not exist" {
             {Assert-DatabaseExists -Instance Instance -ExpectedDb NotThere} | Should -Throw -ExpectedMessage "We expect NotThere to be on Instance"
         }
     }

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -417,7 +417,7 @@ Describe "Checking Instance.Tests.ps1 checks" -Tag UnitTest {
         It "Should pass correctly when the trace flag exists and it is not the one expected to be running" {
             Assert-NotTraceFlag -SQLInstance Dummy -NotExpectedTraceFlag 117
         }
-        It "Should pass correctly when no trace flag is runnign" {
+        It "Should pass correctly when no trace flag is running" {
 			Mock Get-DbaTraceFlag {}
             Assert-NotTraceFlag -SQLInstance Dummy -NotExpectedTraceFlag 117
         }

--- a/tests/checks/ServerChecks.Tests.ps1
+++ b/tests/checks/ServerChecks.Tests.ps1
@@ -73,7 +73,7 @@ Describe "Checking ServerChecks.Tests" {
             }
         }
 
-        it "should fail when any SQLDisks is formatted with a block allocation unit size that isnt 65536b (64KB)" {
+        it "Should fail when any SQLDisks is formatted with a block allocation unit size that isn't 65536b (64KB)" {
             Mock Test-DbaDiskAllocation {
                 @(
                     [PSObject]@{
@@ -641,9 +641,9 @@ Describe "Checking ServerChecks.Tests" {
         
         $ServerInfo = Get-AllServerInfo -ComputerName Dummy -Tags $tags
         It "Should get the right results for PingComputer" {
-            $serverInfo.PingComputer.Count | Should -Be -1 -Because "This is what the functionshould return for no server"
-            $serverInfo.PingComputer[0].Address | Should -BeNullOrEmpty -Because "This is what the functionshould return for no server"
-            $serverInfo.PingComputer[0].ResponseTime  | Should -Be 50000000  -Because "This is what the functionshould return for no server"
+            $serverInfo.PingComputer.Count | Should -Be -1 -Because "This is what the function should return for no server"
+            $serverInfo.PingComputer[0].Address | Should -BeNullOrEmpty -Because "This is what the function should return for no server"
+            $serverInfo.PingComputer[0].ResponseTime  | Should -Be 50000000  -Because "This is what the function should return for no server"
         }
         It "Should get the right results for DiskAllocationUnit" {
             $serverInfo.DiskAllocation[0].Name | Should -Be '? '  # Yes there is a space for formatting the PowerBi
@@ -651,14 +651,14 @@ Describe "Checking ServerChecks.Tests" {
             $serverInfo.DiskAllocation[0].isSqlDisk| Should -BeTrue
         }
         It "Should get the right results for PowerPlan" {
-            $serverInfo.PowerPlan | Should -Be 'An Error occured'
+            $serverInfo.PowerPlan | Should -Be 'An Error occurred'
         }
         It "Should get the right results for SPN" {
-            $serverInfo.SPNs[0].Error | Should -Be 'An Error Occured'
+            $serverInfo.SPNs[0].Error | Should -Be 'An Error occurred'
             $serverInfo.SPNs[0].RequiredSPN | Should -Be 'Dont know the SPN'
         }
         It "Should get the right results for DiskCapacity" {
-            $serverInfo.DiskSpace.ComputerName| Should -Be 'An Error occured Dummy' 
+            $serverInfo.DiskSpace.ComputerName| Should -Be 'An Error occurred Dummy' 
             $serverInfo.DiskSpace.Name | Should -Be 'Do not know the Name'
             $serverInfo.DiskSpace.PercentFree | Should -Be -1
         }
@@ -771,7 +771,7 @@ Describe "Checking ServerChecks.Tests" {
             $serverInfo.DiskAllocation | Should -BeNullOrEmpty
         }
         It "Should get the right results for PowerPlan" {
-            $serverInfo.PowerPlan | Should -Be 'An Error occured'
+            $serverInfo.PowerPlan | Should -Be 'An Error occurred'
         }
         It "Should have no results for SPN" {
             $serverInfo.SPNs | Should -BeNullOrEmpty
@@ -972,9 +972,9 @@ Describe "Checking ServerChecks.Tests" {
         
         $ServerInfo = Get-AllServerInfo -ComputerName Dummy -Tags $tags
         It "Should get the right results for PingComputer" {
-            $serverInfo.PingComputer.Count | Should -Be -1 -Because "This is what the functionshould return for no server"
-            $serverInfo.PingComputer[0].Address | Should -BeNullOrEmpty -Because "This is what the functionshould return for no server"
-            $serverInfo.PingComputer[0].ResponseTime  | Should -Be 50000000  -Because "This is what the functionshould return for no server"
+            $serverInfo.PingComputer.Count | Should -Be -1 -Because "This is what the function should return for no server"
+            $serverInfo.PingComputer[0].Address | Should -BeNullOrEmpty -Because "This is what the function should return for no server"
+            $serverInfo.PingComputer[0].ResponseTime  | Should -Be 50000000  -Because "This is what the function should return for no server"
       
         }
         It "Should have no results for DiskAllocationUnit" {
@@ -1271,7 +1271,7 @@ Describe "Checking ServerChecks.Tests" {
             $serverInfo.PowerPlan | Should -BeNullOrEmpty
         }
         It "Should have the right results for SPN" {
-            $serverInfo.SPNs[0].Error | Should -Be 'An Error Occured'
+            $serverInfo.SPNs[0].Error | Should -Be 'An Error occurred'
             $serverInfo.SPNs[0].RequiredSPN | Should -Be 'Dont know the SPN'
         }
         It "Should have no results for DiskCapacity" {
@@ -1578,7 +1578,7 @@ Describe "Checking ServerChecks.Tests" {
             $serverInfo.SPNs| Should -BeNullOrEmpty
         }
         It "Should have the right results for DiskCapacity" {
-            $serverInfo.DiskSpace.ComputerName| Should -Be 'An Error occured Dummy' 
+            $serverInfo.DiskSpace.ComputerName| Should -Be 'An Error occurred Dummy' 
             $serverInfo.DiskSpace.Name | Should -Be 'Do not know the Name'
             $serverInfo.DiskSpace.PercentFree | Should -Be -1
         }
@@ -1974,11 +1974,11 @@ Describe "Checking ServerChecks.Tests" {
             $serverInfo.PowerPlan | Should -BeNullOrEmpty
         }
         It "Should get the right results for SPN" {
-            $serverInfo.SPNs[0].Error | Should -Be 'An Error Occured'
+            $serverInfo.SPNs[0].Error | Should -Be 'An Error occurred'
             $serverInfo.SPNs[0].RequiredSPN | Should -Be 'Dont know the SPN'
         }
         It "Should have the right results for DiskCapacity" {
-            $serverInfo.DiskSpace.ComputerName| Should -Be 'An Error occured Dummy' 
+            $serverInfo.DiskSpace.ComputerName| Should -Be 'An Error occurred Dummy' 
             $serverInfo.DiskSpace.Name | Should -Be 'Do not know the Name'
             $serverInfo.DiskSpace.PercentFree | Should -Be -1
         }

--- a/tests/functions/Get-CheckInformation.tests.ps1
+++ b/tests/functions/Get-CheckInformation.tests.ps1
@@ -23,7 +23,7 @@ Describe "Testing Get-CheckInformation" -Tag Get-CheckInformation, Unittest {
             Get-CheckInformation -Group Server -Check Server | Should -Be 'PowerPlan', 'InstanceConnection', 'Connectivity', 'SPN', 'DiskCapacity', 'Storage', 'DISA', 'PingComputer', 'CPUPrioritisation', 'DiskAllocationUnit' -Because 'When the Check is specified and is a group it should return all of the tags for that group and not the groupname if nothing is exclueded'
         }
         It "Should Return All of the checks for a group When AllChecks is specified and nothing excluded" {
-            Get-CheckInformation -Group Server -AllChecks $true | Should -Be 'PowerPlan', 'InstanceConnection', 'Connectivity', 'SPN', 'DiskCapacity', 'Storage', 'DISA', 'PingComputer', 'CPUPrioritisation', 'DiskAllocationUnit' -Because 'When AllChecks is specified  it should return all of the tags for that group and not the groupname if nothing is exclueded'
+            Get-CheckInformation -Group Server -AllChecks $true | Should -Be 'PowerPlan', 'InstanceConnection', 'Connectivity', 'SPN', 'DiskCapacity', 'Storage', 'DISA', 'PingComputer', 'CPUPrioritisation', 'DiskAllocationUnit' -Because 'When AllChecks is specified  it should return all of the tags for that group and not the groupname if nothing is excluded'
         }
         It "Should Return one check for a group when one unique tag is specified and nothing excluded" {
             Get-CheckInformation -Group Server -Check SPN | Should -Be  'SPN' -Because 'When a Check is specified it should return just that check'

--- a/tests/functions/get-check.json
+++ b/tests/functions/get-check.json
@@ -392,7 +392,7 @@
         "UniqueTag":  "DatabaseExists",
         "AllTags":  "DatabaseExists, Database",
         "Config":  "app.sqlinstance database.exists ",
-        "Description":  "Tests that the databases are specified are on the instance (Note - Does not check if they are avaiable - Use DatabaseStatus for that))",
+        "Description":  "Tests that the databases are specified are on the instance (Note - Does not check if they are available - Use DatabaseStatus for that))",
         "Describe":  "Database Exists"
     },
     {
@@ -415,7 +415,7 @@
     },
     {
         "Group":  "HADR",
-        "Type":  "ClusteNode",
+        "Type":  "ClusterNode",
         "UniqueTag":  "ClusterHealth",
         "AllTags":  "ClusterHealth, HADR",
         "Config":  "app.cluster skip.hadr.listener.pingcheck domain.name policy.hadr.tcpport ",


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

[x] There are 0 failing Pester tests

```## Load the module
Import-Module .\dbachecks.psd1
## Run the Unit test
Invoke-Pester .\tests -ExcludeTag Integration
...
Tests Passed: 1588, Failed: 0, Skipped: 1, Pending: 0, Inconclusive: 0
```

## Changes this PR brings

 * Spell checked all files and corrected some typos