### PR TITLE
"SA Rename" check using wrong dbatools command name.

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -326,7 +326,7 @@ $filename = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
         }
         else {
             Context "Checking that sa login has been renamed on $psitem" {
-                $results = Get-DbaErrorLogin -SqlInstance $psitem -Login sa
+                $results = Get-DbaLogin -SqlInstance $psitem -Login sa
                 It "sa login does not exist on $psitem" {
                     $results | Should -Be $null -Because 'Renaming the sa account is a requirement'
                 }


### PR DESCRIPTION
Fix dbatools command name from `Get-DbaErrorLogin` to `Get-DbaLogin`

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[x] There are 0 failing Pester tests

## Changes this PR brings
 - Fix #572 

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)
 - "SA Renamed" was calling an unexisting dbatools command. `Get-DbaErrorLogin` instead of `Get-DbaLogin`