### PR TITLE
Put $null on left side

### DIFF
--- a/internal/functions/Get-CheckInformation.ps1
+++ b/internal/functions/Get-CheckInformation.ps1
@@ -27,7 +27,7 @@ function Get-CheckInformation {
 
     # So Lets fix that!
 
-    if($Check -eq $null){
+    if($null -eq $Check){
         $Check = $GroupChecks
     }
 


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesn't need an essay just the bullet points :-)

Adding this change due to best practice requiring $null on the left side of the comparison

[Best Practice](https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation/PossibleIncorrectComparisonWithNull.md)