### PR TITLE
Import-DbcConfig - do not import invalid mail configs

### DIFF
--- a/functions/Import-DbcConfig.ps1
+++ b/functions/Import-DbcConfig.ps1
@@ -55,7 +55,6 @@ function Import-DbcConfig {
         }
 
         foreach ($result in $results) {
-            if ($result.Name -match 'mail' -and (-not $result.Value)) { continue }
             Set-DbcConfig -Name $result.Name -Value $result.Value -Temporary:$Temporary
         }
     }

--- a/functions/Import-DbcConfig.ps1
+++ b/functions/Import-DbcConfig.ps1
@@ -55,6 +55,7 @@ function Import-DbcConfig {
         }
 
         foreach ($result in $results) {
+            if ($result.Name -match 'mail' -and (-not $result.Value)) { continue }
             Set-DbcConfig -Name $result.Name -Value $result.Value -Temporary:$Temporary
         }
     }

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -8,7 +8,7 @@ Register-PSFConfigValidation -Name validation.LogFileComparisonValidations -Scri
 $EmailValidationSb = {
     param ([string]$input)
     $EmailRegEx = "^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$"
-    if ($input -match $EmailRegEx) {
+    if (($input -match $EmailRegEx) -or ($null -eq $input)) {
         [PsCustomObject]@{Success = $true; value = $input}
     } else {
         [PsCustomObject]@{Success = $false; message = "does not appear to be an email address - $input"}
@@ -235,7 +235,7 @@ Set-PSFConfig -Module dbachecks -Name domain.domaincontroller -Value $null -Init
 
 # email
 Set-PSFConfig -Module dbachecks -Name mail.failurethreshhold -Value 0 -Initialize -Description "Number of errors that must be present to generate an email report"
-Set-PSFConfig -Module dbachecks -Name mail.smtpserver -Value $null -Validation string -Initialize -Description "Store the name of the smtp server to send email reports"
+Set-PSFConfig -Module dbachecks -Name mail.smtpserver -Value $null -Initialize -Description "Store the name of the smtp server to send email reports"
 Set-PSFConfig -Module dbachecks -Name mail.to -Value $null -Validation validation.EmailValidation -Initialize -Description "Email address to send the report to"
 Set-PSFConfig -Module dbachecks -Name mail.from  -Value $null -Validation validation.EmailValidation -Initialize -Description "Email address the email reports should come from"
 Set-PSFConfig -Module dbachecks -Name mail.subject  -Value 'dbachecks results' -Validation String -Initialize -Description "Subject line of the email report"


### PR DESCRIPTION
fixes this

![image](https://user-images.githubusercontent.com/8278033/52178999-39a2d200-27d5-11e9-83e2-73fd5354db66.png)

confirmed that it happens even with fresh install on new server