### PR TITLE
Stop HADR checks pulling through IP resource

### DIFF
--- a/checks/HADR.Tests.ps1
+++ b/checks/HADR.Tests.ps1
@@ -85,7 +85,7 @@ foreach ($clustervm in $clusters) {
         }
         Context "Cluster resources for $clustername" {
             # Get the resources that are no IP Addresses with an owner of Availability Group
-            $return.Resources.Where{$_.ResourceType -notin ($_.ResourceType -eq 'IP Address' -and $_.OwnerGroup -in $Return.Ags)}.ForEach{
+            $return.Resources.Where{$_.ResourceType -in ($_.ResourceType -ne 'IP Address' -and $_.OwnerGroup -in $Return.Ags)}.ForEach{
                 It "Resource $($psitem.Name) should be online" {
                     $psitem.State | Should -Be 'Online' -Because 'All of the cluster resources should be online'
                 }

--- a/checks/HADR.Tests.ps1
+++ b/checks/HADR.Tests.ps1
@@ -85,7 +85,7 @@ foreach ($clustervm in $clusters) {
         }
         Context "Cluster resources for $clustername" {
             # Get the resources that are no IP Addresses with an owner of Availability Group
-            $return.Resources.Where{$_.ResourceType -in ($_.ResourceType -ne 'IP Address' -and $_.OwnerGroup -in $Return.Ags)}.ForEach{
+            $return.Resources.Where{ ( $_.ResourceType -in ($_.ResourceType -ne 'IP Address') ) -and ($_.OwnerGroup -in $Return.Ags) }.ForEach{
                 It "Resource $($psitem.Name) should be online" {
                     $psitem.State | Should -Be 'Online' -Because 'All of the cluster resources should be online'
                 }


### PR DESCRIPTION
There are 0 failing Pester tests

## Changes this PR brings

A minor change to a conditional filter on the pipeline. 

Current test pulls back IP resources for the OwnerGroup 'Cluster Group' and fails because IP resource can and might be offline.

```
Name                    State   OwnerGroup       ResourceType
----                    -----   ----------       ------------
IP Address 10.253.51.51 Online  Cluster Group    IP Address
IP Address 10.253.52.51 Offline Cluster Group    IP Address
```

I believe this is original intention and all IP address resources should be ignored. 

