### PR TITLE
Issue 116 - Labeled exisiting test that are related to CIS audits

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -785,7 +785,7 @@ $ExcludedDatabases += $ExcludeDatabase
         }
     }
 
-    Describe "Database Orphaned User" -Tags OrphanedUser, Medium, $filename {
+    Describe "Database Orphaned User" -Tags OrphanedUser, CIS, Medium, $filename {
         if ($NotContactable -contains $psitem) {
             Context "Testing database orphaned user event on $psitem" {
                 It "Can't Connect to $Psitem" {

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -192,7 +192,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
     }
 
-    Describe "Dedicated Administrator Connection" -Tags DAC, Low, $filename {
+    Describe "Dedicated Administrator Connection" -Tags DAC, CIS, Low, $filename {
         $dac = Get-DbcConfigValue policy.dacallowed
         if ($NotContactable -contains $psitem) {
             Context "Testing Dedicated Administrator Connection on $psitem" {
@@ -369,7 +369,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
     }
 
-    Describe "SA Login Renamed" -Tags SaRenamed, DISA, Medium, $filename {
+    Describe "SA Login Renamed" -Tags SaRenamed, DISA, CIS, Medium, $filename {
         if ($NotContactable -contains $psitem) {
             Context "Checking that sa login has been renamed on $psitem" {
                 It "Can't Connect to $Psitem" {
@@ -484,7 +484,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             Write-Warning "You need to use Set-DbcConfig -Name policy.xevent.validrunningsession -Value to add some Extended Events session names to run this check"
         }
     }
-    Describe "OLE Automation" -Tags OLEAutomation, security, Medium, $filename {
+    Describe "OLE Automation" -Tags OLEAutomation, security, CIS, Medium, $filename {
         $OLEAutomation = Get-DbcConfigValue policy.oleautomation
         if ($NotContactable -contains $psitem) {
             Context "Testing OLE Automation on $psitem" {
@@ -633,7 +633,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
     }
 
-    Describe "Error Log Count" -Tags ErrorLogCount, Low, $filename {
+    Describe "Error Log Count" -Tags ErrorLogCount, CIS, Low, $filename {
         $errorLogCount = Get-DbcConfigValue policy.errorlog.logcount
         if ($NotContactable -contains $psitem) {
             Context "Checking error log count on $psitem" {
@@ -726,7 +726,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
     }
 
-    Describe "CLR Enabled" -Tags CLREnabled, security, High, $filename {
+    Describe "CLR Enabled" -Tags CLREnabled, security, CIS, High, $filename {
         $CLREnabled = Get-DbcConfigValue policy.security.clrenabled
         if ($NotContactable -contains $psitem) {
             Context "Testing CLR Enabled on $psitem" {
@@ -744,7 +744,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
     }
 
-    Describe "Cross Database Ownership Chaining" -Tags CrossDBOwnershipChaining, security, Medium, $filename {
+    Describe "Cross Database Ownership Chaining" -Tags CrossDBOwnershipChaining, security, CIS, Medium, $filename {
         $CrossDBOwnershipChaining = Get-DbcConfigValue policy.security.crossdbownershipchaining
         if ($NotContactable -contains $psitem) {
             Context "Testing Cross Database Ownership Chaining on $psitem" {
@@ -761,7 +761,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
-    Describe "Ad Hoc Distributed Queries" -Tags AdHocDistributedQueriesEnabled, security, Medium, $filename {
+    Describe "Ad Hoc Distributed Queries" -Tags AdHocDistributedQueriesEnabled, security, CIS, Medium, $filename {
         $AdHocDistributedQueriesEnabled = Get-DbcConfigValue policy.security.AdHocDistributedQueriesEnabled
         if ($NotContactable -contains $psitem) {
             Context "Testing Ad Hoc Distributed Queries on $psitem" {
@@ -778,7 +778,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
-    Describe "XP CmdShell" -Tags XpCmdShellDisabled, security, Medium, $filename {
+    Describe "XP CmdShell" -Tags XpCmdShellDisabled, security, CIS, Medium, $filename {
         $XpCmdShellDisabled = Get-DbcConfigValue policy.security.XpCmdShellDisabled
         if ($NotContactable -contains $psitem) {
             Context "Testing XP CmdShell on $psitem" {


### PR DESCRIPTION
# CIS Labels

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

Technically all I did was add tags.
[X] There are 0 failing Pester tests

## Changes this PR brings

Tags for existing CIS Audit tests.