### PR TITLE
Long running jobs

### DIFF
--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -340,6 +340,73 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
                         }
                     }   
                 }
+                Describe "Last Agent Job Run" -Tags LastJobRunTime, $filename {
+                    $skip = Get-DbcConfigValue skip.agent.lastjobruntime
+                    $runningjobpercentage = Get-DbcConfigValue agent.lastjobruntime.percentage
+                    if (-not $skip) {
+                        $query = "IF OBJECT_ID('tempdb..#dbachecksLastRunTime') IS NOT NULL DROP Table #dbachecksLastRunTime
+                        SELECT * INTO #dbachecksLastRunTime
+                        FROM
+                        (
+                        SELECT
+                        j.job_id,
+                        j.name AS JobName,
+                        jh.run_duration AS Duration
+                        FROM msdb.dbo.sysjobs j 
+                        INNER JOIN
+                            (
+                                SELECT job_id, instance_id = MAX(instance_id)
+                                    FROM msdb.dbo.sysjobhistory
+                                    GROUP BY job_id
+                            ) AS h
+                            ON j.job_id = h.job_id
+                        INNER JOIN
+                            msdb.dbo.sysjobhistory AS jh
+                            ON jh.job_id = h.job_id
+                            AND jh.instance_id = h.instance_id
+                        ) AS lrt
+                        
+                        IF OBJECT_ID('tempdb..#dbachecksAverageRunTime') IS NOT NULL DROP Table #dbachecksAverageRunTime
+                        SELECT * INTO #dbachecksAverageRunTime
+                        FROM
+                        (
+                        SELECT 
+                        job_id,
+                        AVG(DATEDIFF(SECOND, 0, STUFF(STUFF(RIGHT('000000' + CONVERT(VARCHAR(6),run_duration),6),5,0,':'),3,0,':'))) AS AvgSec
+                        FROM msdb.dbo.sysjobhistory hist
+                        GROUP BY job_id
+                        ) as art
+                        
+                        SELECT 
+                        JobName,
+                        Duration,
+                        AvgSec,
+                        Duration - AvgSec AS Diff
+                        FROM #dbachecksLastRunTime lastrun
+                        JOIN #dbachecksAverageRunTime avgrun
+                        ON lastrun.job_id = avgrun.job_id
+                        
+                        DROP Table #dbachecksLastRunTime
+                        DROP Table #dbachecksAverageRunTime"
+                        $lastagentjobruns = Invoke-DbaQuery -SqlInstance $PSItem -Database msdb -Query $query
+                    }
+                    if ($NotContactable -contains $psitem) {
+                        Context "Testing last job run time on $psitem" {
+                            It "Can't Connect to $Psitem" {
+                                $false  |  Should -BeTrue -Because "The instance should be available to be connected to!"
+                            }
+                        }
+                    }
+                    else {    
+                        Context "Testing last job run time on $psitem" {
+                            foreach ($lastagentjobrun in $lastagentjobruns) {
+                                It "Job $($lastagentjobrun.JobName) last run duration should be less than $runningjobpercentage % of average run time on $psitem" -Skip:$skip {
+                                    Assert-LastJobRun -lastagentjobrun $lastagentjobrun -runningjobpercentage $runningjobpercentage
+                                }
+                            }
+                        }
+                    }   
+                }
             }
         }
     }

--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -332,7 +332,7 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
                     }
                     else {    
                         Context "Testing long running jobs on $psitem" {
-                            foreach ($runningjob in $runningjobs) {
+                            foreach ($runningjob in $runningjobs| Where-Object {$_.AvgSec -ne 0}) {
                                 It "Running job $($runningjob.JobName) duration should be less than $runningjobpercentage % of average run time on $psitem" -Skip:$skip {
                                     Assert-LongRunningJobs -runningjob $runningjob -runningjobpercentage $runningjobpercentage
                                 }
@@ -399,7 +399,7 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
                     }
                     else {    
                         Context "Testing last job run time on $psitem" {
-                            foreach ($lastagentjobrun in $lastagentjobruns) {
+                            foreach ($lastagentjobrun in $lastagentjobruns | Where-Object {$_.AvgSec -ne 0}) {
                                 It "Job $($lastagentjobrun.JobName) last run duration should be less than $runningjobpercentage % of average run time on $psitem" -Skip:$skip {
                                     Assert-LastJobRun -lastagentjobrun $lastagentjobrun -runningjobpercentage $runningjobpercentage
                                 }

--- a/internal/assertions/Agent.Assertions.ps1
+++ b/internal/assertions/Agent.Assertions.ps1
@@ -30,6 +30,12 @@ function Assert-JobHistoryRowsPerJob {
     $AgentServer.MaximumJobHistoryRows | Should -BeGreaterOrEqual $minimumJobHistoryRowsPerJob -Because "We expect the maximum job history row configuration per agent job to be greater than the configured setting $minimumJobHistoryRowsPerJob"
 }
 
+
+function Assert-LongRunningJobs {
+    Param($runningjob,$runningjobpercentage)
+    [math]::Round($runningjob.Diff/$runningjob.AvgSec * 100) | Should -BeLessThan $runningjobpercentage -Because "The current running job $($runningjob.JobName) has been running for $($runningjob.Diff) seconds longer than the average run time. This is more than the $runningjobpercentage % specified as the maximum"
+}
+
 # SIG # Begin signature block
 # MIINEAYJKoZIhvcNAQcCoIINATCCDP0CAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
 # gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR

--- a/internal/assertions/Agent.Assertions.ps1
+++ b/internal/assertions/Agent.Assertions.ps1
@@ -35,6 +35,10 @@ function Assert-LongRunningJobs {
     Param($runningjob,$runningjobpercentage)
     [math]::Round($runningjob.Diff/$runningjob.AvgSec * 100) | Should -BeLessThan $runningjobpercentage -Because "The current running job $($runningjob.JobName) has been running for $($runningjob.Diff) seconds longer than the average run time. This is more than the $runningjobpercentage % specified as the maximum"
 }
+function Assert-LastJobRun {
+    Param($lastagentjobrun,$runningjobpercentage)
+    [math]::Round($lastagentjobrun.Diff/$lastagentjobrun.AvgSec * 100) | Should -BeLessThan $runningjobpercentage -Because "The last run of job $($lastagentjobrun.JobName) was $($lastagentjobrun.duration) seconds. This is more than the $runningjobpercentage % specified as the maximum variance"
+}
 
 # SIG # Begin signature block
 # MIINEAYJKoZIhvcNAQcCoIINATCCDP0CAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -410,5 +410,9 @@
     {
         "UniqueTag": "DefaultTrace",
         "Description": "Tests that the default trace configuration is set to enabled"
+    },
+    {
+        "UniqueTag": "LongRunningJob",
+        "Description": "Tests that any currently running agent jobs have not been running for longer than the configured percentage (default 50) of time than the average job run"
     }
  ]

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -413,6 +413,10 @@
     },
     {
         "UniqueTag": "LongRunningJob",
-        "Description": "Tests that any currently running agent jobs have not been running for longer than the configured percentage (default 50) of time than the average job run"
+        "Description": "Tests that any currently running agent jobs have not been running for longer than the configured percentage (default 50) of time more than the average job run"
+    },
+    {
+        "UniqueTag": "LastJobRunTime",
+        "Description": "Tests that the last duration of the agent jobs were not longer than the configured percentage (default 50) of time more than the average job run"
     }
  ]

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -223,6 +223,7 @@ Set-PSFConfig -Module dbachecks -Name skip.instance.modeldbgrowth -Validation bo
 Set-PSFConfig -Module dbachecks -Name skip.hadr.listener.pingcheck -Validation bool -Value $false -Initialize -Description "Skip the HADR listener ping test (expecially useful for Azure and AWS)"
 Set-PSFConfig -Module dbachecks -Name skip.instance.defaulttrace -Validation bool -Value $false -Initialize -Description "Skip the default trace check"
 Set-PSFConfig -Module dbachecks -Name skip.agent.longrunningjobs -Validation bool -Value $false -Initialize -Description "Skip the long running agent jobs check"
+Set-PSFConfig -Module dbachecks -Name skip.agent.lastjobruntime -Validation bool -Value $false -Initialize -Description "Skip the last agent job time check"
 
 #agent
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatorname -Value $null -Initialize -Description "Name of the DBA Operator in SQL Agent"
@@ -239,6 +240,7 @@ Set-PSFConfig -Module dbachecks -Name agent.history.maximumjobhistoryrows -Value
 Set-PSFConfig -Module dbachecks -Name agent.failedjob.excludecancelled -Value $false -Initialize -Description "Exclude agent jobs with a status of cancelled"
 Set-PSFConfig -Module dbachecks -Name agent.failedjob.since -Value 30 -Initialize -Description "The maximum number of days to check for failed jobs"
 Set-PSFConfig -Module dbachecks -Name agent.longrunningjob.percentage -Value 50 -Initialize -Description "The maximum percentage variance that a currently running job is allowed over the average for that job"
+Set-PSFConfig -Module dbachecks -Name agent.lastjobruntime.percentage -Value 50 -Initialize -Description "The maximum percentage variance that the last run of a job is allowed over the average for that job"
 
 # domain
 Set-PSFConfig -Module dbachecks -Name domain.name -Value $null -Initialize -Description "The Active Directory domain that your server is a part of"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -222,6 +222,7 @@ Set-PSFConfig -Module dbachecks -Name skip.logshiptesting -Validation bool -Valu
 Set-PSFConfig -Module dbachecks -Name skip.instance.modeldbgrowth -Validation bool -Value $false -Initialize -Description "Skip the model database growth settings test"
 Set-PSFConfig -Module dbachecks -Name skip.hadr.listener.pingcheck -Validation bool -Value $false -Initialize -Description "Skip the HADR listener ping test (expecially useful for Azure and AWS)"
 Set-PSFConfig -Module dbachecks -Name skip.instance.defaulttrace -Validation bool -Value $false -Initialize -Description "Skip the default trace check"
+Set-PSFConfig -Module dbachecks -Name skip.agent.longrunningjobs -Validation bool -Value $false -Initialize -Description "Skip the long running agent jobs check"
 
 #agent
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatorname -Value $null -Initialize -Description "Name of the DBA Operator in SQL Agent"
@@ -237,6 +238,7 @@ Set-PSFConfig -Module dbachecks -Name agent.history.maximumhistoryrows -Value 10
 Set-PSFConfig -Module dbachecks -Name agent.history.maximumjobhistoryrows -Value 100 -Initialize -Description "Maximum job history row per job. When the property is disabled the value is 0."
 Set-PSFConfig -Module dbachecks -Name agent.failedjob.excludecancelled -Value $false -Initialize -Description "Exclude agent jobs with a status of cancelled"
 Set-PSFConfig -Module dbachecks -Name agent.failedjob.since -Value 30 -Initialize -Description "The maximum number of days to check for failed jobs"
+Set-PSFConfig -Module dbachecks -Name agent.longrunningjob.percentage -Value 50 -Initialize -Description "The maximum percentage variance that a currently running job is allowed over the average for that job"
 
 # domain
 Set-PSFConfig -Module dbachecks -Name domain.name -Value $null -Initialize -Description "The Active Directory domain that your server is a part of"

--- a/tests/Unit.Tests.ps1
+++ b/tests/Unit.Tests.ps1
@@ -124,7 +124,7 @@ Describe "Checking that each dbachecks Pester test is correctly formatted for Po
                             }
                         }
                         It "$CheckName should have the right number of Context blocks as the AST doesnt parse how I like and I cant be bothered to fix it right now"{
-                            $Contexts.Count | Should -Be 20 -Because "There should be 20 context blocks in the Agent checks file"
+                            $Contexts.Count | Should -Be 24 -Because "There should be 24 context blocks in the Agent checks file"
                         }
                     }
                 }

--- a/tests/checks/AgentChecks.Tests.ps1
+++ b/tests/checks/AgentChecks.Tests.ps1
@@ -1,7 +1,7 @@
 # load all of the assertion functions
 (Get-ChildItem $PSScriptRoot/../../internal/assertions/).ForEach{. $Psitem.FullName}
 
-Describe "Checking Agent.Tests.ps1 checks" -Tag UnitTest {
+Describe "Checking Agent.Tests.ps1 checks" -Tag UnitTest, AgentAssertions {
     Context "Checking Database Mail XPs" {
         # Mock the version check for running tests
         Mock Connect-DbaInstance {}
@@ -111,6 +111,60 @@ Describe "Checking Agent.Tests.ps1 checks" -Tag UnitTest {
                 'Exactly'     = $true
             }
             Assert-MockCalled @assertMockParams
+        }
+    }
+
+    Context "Checking running jobs"{
+        It "Should pass when the running job duration is less than the average job duration" {
+            # Mock to pass
+            $runningjob = @{
+                JobName        = 'Waiting for 5 seconds'
+                AvgSec         = 38
+                StartDate      = '30/07/2019 12:17:25'
+                RunningSeconds = 24
+                Diff           = -14
+            }
+            $runningjobpercentage = 50
+            Assert-LongRunningJobs -runningjob $runningjob -runningjobpercentage $runningjobpercentage
+        }
+
+        It "Should pass when the running job duration is the same as the average job duration" {
+            # Mock to pass
+            $runningjob = @{
+                JobName        = 'Waiting for 5 seconds'
+                AvgSec         = 38
+                StartDate      = '30/07/2019 12:17:25'
+                RunningSeconds = 38
+                Diff           = 0
+            }
+            $runningjobpercentage = 50
+            Assert-LongRunningJobs -runningjob $runningjob -runningjobpercentage $runningjobpercentage
+        }
+
+        It "Should pass when the running job duration is more than the average job duration but the percentage difference is less than the specified" {
+            # Mock to pass
+            $runningjob = @{
+                JobName        = 'Waiting for 5 seconds'
+                AvgSec         = 38
+                StartDate      = '30/07/2019 12:17:25'
+                RunningSeconds = 50
+                Diff           = 12
+            }
+            $runningjobpercentage = 50
+            Assert-LongRunningJobs -runningjob $runningjob -runningjobpercentage $runningjobpercentage
+        }
+
+        It "Should fail when the running job duration is more than the average job duration and the percentage difference is more than the specified" {
+            # Mock to fail
+            $runningjob = @{
+                JobName        = 'Waiting for 5 seconds'
+                AvgSec         = 38
+                StartDate      = '30/07/2019 12:17:25'
+                RunningSeconds = 78
+                Diff           = 40
+            }
+            $runningjobpercentage = 50
+            {Assert-LongRunningJobs -runningjob $runningjob -runningjobpercentage $runningjobpercentage} | Should -Throw -ExpectedMessage "Expected the actual value to be less than 50, because The current running job Waiting for 5 seconds has been running for 40 seconds longer than the average run time. This is more than the 50 % specified as the maximum, but got 105"
         }
     }
 }

--- a/tests/checks/AgentChecks.Tests.ps1
+++ b/tests/checks/AgentChecks.Tests.ps1
@@ -167,6 +167,55 @@ Describe "Checking Agent.Tests.ps1 checks" -Tag UnitTest, AgentAssertions {
             {Assert-LongRunningJobs -runningjob $runningjob -runningjobpercentage $runningjobpercentage} | Should -Throw -ExpectedMessage "Expected the actual value to be less than 50, because The current running job Waiting for 5 seconds has been running for 40 seconds longer than the average run time. This is more than the 50 % specified as the maximum, but got 105"
         }
     }
+    Context "Checking last run time"{
+        It "Should pass when the last job run duration is less than the average job duration" {
+            # Mock to pass
+            $lastagentjobrun  = @{
+                JobName        = 'Waiting for 5 seconds'
+                AvgSec         = 38
+                Duration       = 25
+                Diff           = -13
+            }
+            $runningjobpercentage = 50
+            Assert-LastJobRun -lastagentjobrun $lastagentjobrun -runningjobpercentage $runningjobpercentage
+        }
+
+        It "Should pass when the last job run duration is the same as the average job duration" {
+            # Mock to pass
+            $lastagentjobrun  = @{
+                JobName        = 'Waiting for 5 seconds'
+                AvgSec         = 38
+                Duration       = 38
+                Diff           = 0
+            }
+            $runningjobpercentage = 50
+            Assert-LastJobRun -lastagentjobrun $lastagentjobrun -runningjobpercentage $runningjobpercentage
+        }
+
+        It "Should pass when the last job run duration is more than the average job duration but the percentage difference is less than the specified" {
+            # Mock to pass
+            $lastagentjobrun  = @{
+                JobName        = 'Waiting for 5 seconds'
+                AvgSec         = 38
+                Duration       = 48
+                Diff           = 10
+            }
+            $runningjobpercentage = 50
+            Assert-LastJobRun -lastagentjobrun $lastagentjobrun -runningjobpercentage $runningjobpercentage
+        }
+
+        It "Should fail when the last job run duration is more than the average job duration and the percentage difference is more than the specified" {
+            # Mock to fail
+            $lastagentjobrun  = @{
+                JobName        = 'Waiting for 5 seconds'
+                AvgSec         = 38
+                Duration       = 68
+                Diff           = 30
+            }
+            $runningjobpercentage = 50
+            {Assert-LastJobRun -lastagentjobrun $lastagentjobrun -runningjobpercentage $runningjobpercentage} | Should -Throw -ExpectedMessage "Expected the actual value to be less than 50, because The last run of job Waiting for 5 seconds was 68 seconds. This is more than the 50 % specified as the maximum variance, but got 79"
+        }
+    }
 }
 # SIG # Begin signature block
 # MIINEAYJKoZIhvcNAQcCoIINATCCDP0CAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB


### PR DESCRIPTION
Adding 2 new checks to check for long running agent jobs
1 for current running jobs and one for last execution
both check against the average run time of the jobs
each have a skip configuration and percentage configuration

closes #239