### PR TITLE
Issue 651 - Scan for Startup Procs 

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -798,19 +798,19 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
-    Describe "Scan For Startup Procedures" -Tags ScanForStartupProcedures, Security, CIS, Medium, $filename {
-        $ScanForStartupProcedures = Get-DbcConfigValue policy.security.ScanForStartupProcedures
+    Describe "Scan For Startup Procedures" -Tags ScanForStartupProceduresDisabled, Security, CIS, Medium, $filename {
+        $skip = Get-DbcConfigValue skip.instance.scanforstartupproceduresdisabled
         if ($NotContactable -contains $psitem) {
             Context "Testing Scan For Startup Procedures on $psitem" {
-                It "Can't Connect to $Psitem" {
+                It "Can't Connect to $Psitem" -Skip:$skip {
                     $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
                 }
             }
         }
         else {
             Context "Testing Scan For Startup Procedures on $psitem" {
-                It "Scan For Startup Procedures is set to $ScanForStartupProcedures on $psitem" {
-                    Assert-ScanForStartupProcedures $AllInstanceInfo
+                It "Scan For Startup Procedures should be disabled on $psitem" -Skip:$skip {
+                    Assert-ScanForStartupProcedures -AllInstanceInfo $AllInstanceInfo
                 }
             }
         }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -794,6 +794,23 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
+    Describe "Scan For Startup Procedures" -Tags StarupProcsDisabled, Security, CIS, Medium, $filename {
+        $ScanForStartupProceduresDisabled = Get-DbcConfigValue policy.security.ScanForStartupProcedures
+        if ($NotContactable -contains $psitem) {
+            Context "Testing Scan For Startup Procedures on $psitem" {
+                It "Can't Connect to $Psitem" {
+                    $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
+                }
+            }
+        }
+        else {
+            Context "Testing Scan For Startup Procedures on $psitem" {
+                It "Scan For Startup Procedures is set to $ScanForStartupProceduresDisabled on $psitem" {
+                    Assert-ScanForStartupProceduresDisabled -SQLInstance $Psitem -ScanForStartupProceduressDisabled $ScanForStartupProceduresDisabled
+                }
+            }
+        }
+    }
     Describe "Default Trace" -Tags DefaultTrace, CIS, Low, $filename {
         $skip = Get-DbcConfigValue skip.instance.defaulttrace
         if ($NotContactable -contains $psitem) {

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -794,7 +794,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
-    Describe "Scan For Startup Procedures" -Tags StarupProcsDisabled, Security, CIS, Medium, $filename {
+    Describe "Scan For Startup Procedures" -Tags ScanForStartupProceduresDisabled, Security, CIS, Medium, $filename {
         $ScanForStartupProceduresDisabled = Get-DbcConfigValue policy.security.ScanForStartupProcedures
         if ($NotContactable -contains $psitem) {
             Context "Testing Scan For Startup Procedures on $psitem" {
@@ -806,7 +806,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         else {
             Context "Testing Scan For Startup Procedures on $psitem" {
                 It "Scan For Startup Procedures is set to $ScanForStartupProceduresDisabled on $psitem" {
-                    Assert-ScanForStartupProceduresDisabled -SQLInstance $Psitem -ScanForStartupProceduressDisabled $ScanForStartupProceduresDisabled
+                    Assert-ScanForStartupProceduresDisabled -SQLInstance $Psitem -ScanForStartupProceduresDisabled $ScanForStartupProceduresDisabled
                 }
             }
         }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -794,8 +794,8 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
-    Describe "Scan For Startup Procedures" -Tags ScanForStartupProceduresDisabled, Security, CIS, Medium, $filename {
-        $ScanForStartupProceduresDisabled = Get-DbcConfigValue policy.security.ScanForStartupProcedures
+    Describe "Scan For Startup Procedures" -Tags ScanForStartupProcedures, Security, CIS, Medium, $filename {
+        $ScanForStartupProcedures = Get-DbcConfigValue policy.security.ScanForStartupProcedures
         if ($NotContactable -contains $psitem) {
             Context "Testing Scan For Startup Procedures on $psitem" {
                 It "Can't Connect to $Psitem" {
@@ -805,8 +805,8 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
         else {
             Context "Testing Scan For Startup Procedures on $psitem" {
-                It "Scan For Startup Procedures is set to $ScanForStartupProceduresDisabled on $psitem" {
-                    Assert-ScanForStartupProceduresDisabled -SQLInstance $Psitem -ScanForStartupProceduresDisabled $ScanForStartupProceduresDisabled
+                It "Scan For Startup Procedures is set to $ScanForStartupProcedures on $psitem" {
+                    Assert-ScanForStartupProcedures $AllInstanceInfo
                 }
             }
         }

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -80,6 +80,29 @@ function Get-AllInstanceInfo {
             }
         }
 
+        'ScanForStartupProcedures' {
+            if ($There) {
+                try {
+                    $SpConfig = Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'ScanForStartupProcedures'
+                    $ScanForStartupProcedures = [pscustomobject] @{
+                        ConfiguredValue = $SpConfig.ConfiguredValue
+                    }
+                }
+                catch {
+                    $There = $false
+                    $ScanForStartupProcedures = [pscustomobject] @{
+                            ConfiguredValue = 'We Could not Connect to $Instance'
+                    }
+                }
+            }
+            else {
+                $There = $false
+                $ScanForStartupProcedures = [pscustomobject] @{
+                        ConfiguredValue = 'We Could not Connect to $Instance'
+                    }
+            }
+        }
+
         'MemoryDump' {
             if ($There) {
                 try {
@@ -109,6 +132,7 @@ function Get-AllInstanceInfo {
         ErrorLog = $ErrorLog
         DefaultTrace = $DefaultTrace
         MaxDump = $MaxDump
+        ScanForStartupProcedures = $ScanForStartupProcedures
     }
 }
 
@@ -249,6 +273,14 @@ function Assert-XpCmdShellDisabled {
         $XpCmdShellDisabled
     )
     (Get-DbaSpConfigure -SqlInstance $SQLInstance -Name XPCmdShellEnabled).ConfiguredValue -eq 0 | Should -Be $XpCmdShellDisabled -Because 'The XP CmdShell setting should be set correctly'
+}
+
+function Assert-ScanForStartupProceduresDisabled {
+    param (
+        $AllInstanceIngo,
+        $ScanForStartupProceduresDisabled
+    )
+    $AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue | Should -Be $ScanForStartupProceduresDisabled -Because 'The Scan For Startup Procedures setting should be set correctly'
 }
 
 function Assert-ErrorLogCount {

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -141,6 +141,10 @@ function Assert-DefaultTrace {
     $AllInstanceInfo.DefaultTrace.ConfiguredValue | Should -Be 1 -Because "We expect the Default Trace to be enabled but got $($AllInstanceInfo.DefaultTrace.Trace.ConfiguredValue)"
 }
 
+function Assert-ScanForStartupProcedures {
+    param ($AllInstanceInfo)
+    $AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue | Should -Be 0 -Because "The scan for startup procedures disabled but got $($AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue)"
+}
 function Assert-MaxDump {
     Param($AllInstanceInfo,$maxdumps)
     $AllInstanceInfo.MaxDump.Count | Should -BeLessThan $maxdumps -Because "We expected less than $maxdumps dumps but found $($AllInstanceInfo.MaxDump.Count). Memory dumps often suggest issues with the SQL Server instance"
@@ -274,15 +278,6 @@ function Assert-XpCmdShellDisabled {
     )
     (Get-DbaSpConfigure -SqlInstance $SQLInstance -Name XPCmdShellEnabled).ConfiguredValue -eq 0 | Should -Be $XpCmdShellDisabled -Because 'The XP CmdShell setting should be set correctly'
 }
-
-function Assert-ScanForStartupProceduresDisabled {
-    param (
-        $AllInstanceInfo,
-        $ScanForStartupProceduresDisabled
-    )
-    $AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue | Should -Be $ScanForStartupProceduresDisabled -Because 'The Scan For Startup Procedures setting should be set correctly'
-}
-
 function Assert-ErrorLogCount {
     param (
         $SQLInstance,

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -277,7 +277,7 @@ function Assert-XpCmdShellDisabled {
 
 function Assert-ScanForStartupProceduresDisabled {
     param (
-        $AllInstanceIngo,
+        $AllInstanceInfo,
         $ScanForStartupProceduresDisabled
     )
     $AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue | Should -Be $ScanForStartupProceduresDisabled -Because 'The Scan For Startup Procedures setting should be set correctly'

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -157,24 +157,24 @@ function Get-AllInstanceInfo {
             }
         }
 
-        'ScanForStartupProcedures' {
+        'ScanForStartupProceduresDisabled' {
             if ($There) {
                 try {
                     $SpConfig = Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'ScanForStartupProcedures'
-                    $ScanForStartupProcedures = [pscustomobject] @{
+                    $ScanForStartupProceduresDisabled = [pscustomobject] @{
                         ConfiguredValue = $SpConfig.ConfiguredValue
                     }
                 }
                 catch {
                     $There = $false
-                    $ScanForStartupProcedures = [pscustomobject] @{
+                    $ScanForStartupProceduresDisabled = [pscustomobject] @{
                             ConfiguredValue = 'We Could not Connect to $Instance'
                     }
                 }
             }
             else {
                 $There = $false
-                $ScanForStartupProcedures = [pscustomobject] @{
+                $ScanForStartupProceduresDisabled = [pscustomobject] @{
                         ConfiguredValue = 'We Could not Connect to $Instance'
                     }
             }
@@ -209,18 +209,18 @@ function Get-AllInstanceInfo {
         ErrorLog = $ErrorLog
         DefaultTrace = $DefaultTrace
         MaxDump = $MaxDump
-        ScanForStartupProcedures = $ScanForStartupProcedures
+        ScanForStartupProceduresDisabled = $ScanForStartupProceduresDisabled
     }
 }
 
 function Assert-DefaultTrace {
     Param($AllInstanceInfo)
-    $AllInstanceInfo.DefaultTrace.ConfiguredValue | Should -Be 1 -Because "We expect the Default Trace to be enabled but got $($AllInstanceInfo.DefaultTrace.Trace.ConfiguredValue)"
+    $AllInstanceInfo.DefaultTrace.ConfiguredValue | Should -Be 1 -Because "We expect the Default Trace to be enabled but got $($AllInstanceInfo.DefaultTrace.ConfiguredValue)"
 }
 
 function Assert-ScanForStartupProcedures {
     param ($AllInstanceInfo)
-    $AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue | Should -Be 0 -Because "We expected the scan for startup procedures to be 0 (disabled) but got $($AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue)"
+    $AllInstanceInfo.ScanForStartupProceduresDisabled.ConfiguredValue | Should -Be 0 -Because "We expected the scan for startup procedures to be disabled but got $($AllInstanceInfo.ScanForStartupProceduresDisabled.ConfiguredValue)"
 }
 function Assert-MaxDump {
     Param($AllInstanceInfo,$maxdumps)

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -220,7 +220,7 @@ function Assert-DefaultTrace {
 
 function Assert-ScanForStartupProcedures {
     param ($AllInstanceInfo)
-    $AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue | Should -Be 0 -Because "The scan for startup procedures disabled but got $($AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue)"
+    $AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue | Should -Be 0 -Because "We expected the scan for startup procedures to be 0 (disabled) but got $($AllInstanceInfo.ScanForStartupProcedures.ConfiguredValue)"
 }
 function Assert-MaxDump {
     Param($AllInstanceInfo,$maxdumps)

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -404,6 +404,10 @@
         "Description": "Tests that the XP CmdShell configuration setting is set as specified (default true - meaning it should be disabled)"
     },
     {
+        "UniqueTag": "ScanForStartupProceduresDisabled",
+        "Description": "Tests that the Scan For Startup Procedures configuration setting is set as specified (default true - meaning it should be disabled)"
+    },
+    {
         "UniqueTag": "JobHistory",
         "Description": "Tests that the job history configuration for max number of rows in the whole agent log is greater than or equal to the specified value (default 1000) and that the max number of rows per job configuration is greater than or equal to the specified value (default 100) ."
     },

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -404,8 +404,8 @@
         "Description": "Tests that the XP CmdShell configuration setting is set as specified (default true - meaning it should be disabled)"
     },
     {
-        "UniqueTag": "ScanForStartupProceduresDisabled",
-        "Description": "Tests that the Scan For Startup Procedures configuration setting is set as specified (default true - meaning it should be disabled)"
+        "UniqueTag": "ScanForStartupProcedures",
+        "Description": "Tests that the Scan For Startup Procedures configuration setting is set as specified (default 0 - meaning it should be disabled)"
     },
     {
         "UniqueTag": "JobHistory",

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -404,7 +404,7 @@
         "Description": "Tests that the XP CmdShell configuration setting is set as specified (default true - meaning it should be disabled)"
     },
     {
-        "UniqueTag": "ScanForStartupProcedures",
+        "UniqueTag": "ScanForStartupProceduresDisabled",
         "Description": "Tests that the Scan For Startup Procedures configuration setting is set as specified (default 0 - meaning it should be disabled)"
     },
     {

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -54,6 +54,7 @@ Set-PSFConfig -Module dbachecks -Name policy.security.crossdbownershipchaining -
 Set-PSFConfig -Module dbachecks -Name policy.security.databasemailenabled -Validation bool -Value $false -Initialize -Description "Database Mail XPs should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.adhocdistributedqueriesenabled -Validation bool -Value $false -Initialize -Description "Ad Hoc Distributed Queries should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.xpcmdshelldisabled -Validation bool -Value $true -Initialize -Description "XP CmdShell should be disabled `$true or enabled `$false"
+Set-PSFConfig -Module dbachecks -Name policy.security.scanforstartupprocedures -Validation bool -Value $true -Initialize -Description "Scan For Startup Procedures should be disabled `$true or enabled `$false"
 
 #diskspce
 Set-PSFConfig -Module dbachecks -Name policy.diskspace.percentfree -Value 20 -Initialize -Description "Percent disk free"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -54,7 +54,7 @@ Set-PSFConfig -Module dbachecks -Name policy.security.crossdbownershipchaining -
 Set-PSFConfig -Module dbachecks -Name policy.security.databasemailenabled -Validation bool -Value $false -Initialize -Description "Database Mail XPs should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.adhocdistributedqueriesenabled -Validation bool -Value $false -Initialize -Description "Ad Hoc Distributed Queries should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.xpcmdshelldisabled -Validation bool -Value $true -Initialize -Description "XP CmdShell should be disabled `$true or enabled `$false"
-Set-PSFConfig -Module dbachecks -Name policy.security.scanforstartupprocedures -Value 0 -Initialize -Description "Scan For Startup Procedures should be disabled 0 or enabled 1"
+Set-PSFConfig -Module dbachecks -Name policy.security.scanforstartupproceduresdisabled -Validation bool -Value $true -Initialize -Description "Scan For Startup Procedures disabled `$true or enabled `$false"
 
 #diskspce
 Set-PSFConfig -Module dbachecks -Name policy.diskspace.percentfree -Value 20 -Initialize -Description "Percent disk free"
@@ -225,6 +225,7 @@ Set-PSFConfig -Module dbachecks -Name skip.hadr.listener.pingcheck -Validation b
 Set-PSFConfig -Module dbachecks -Name skip.instance.defaulttrace -Validation bool -Value $false -Initialize -Description "Skip the default trace check"
 Set-PSFConfig -Module dbachecks -Name skip.agent.longrunningjobs -Validation bool -Value $false -Initialize -Description "Skip the long running agent jobs check"
 Set-PSFConfig -Module dbachecks -Name skip.agent.lastjobruntime -Validation bool -Value $false -Initialize -Description "Skip the last agent job time check"
+Set-PSFConfig -Module dbachecks -Name skip.instance.scanforstartupproceduresdisabled -Validation bool -Value $false -Initialize -Description "Skip the scan for startup procedures check"
 
 #agent
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatorname -Value $null -Initialize -Description "Name of the DBA Operator in SQL Agent"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -54,7 +54,7 @@ Set-PSFConfig -Module dbachecks -Name policy.security.crossdbownershipchaining -
 Set-PSFConfig -Module dbachecks -Name policy.security.databasemailenabled -Validation bool -Value $false -Initialize -Description "Database Mail XPs should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.adhocdistributedqueriesenabled -Validation bool -Value $false -Initialize -Description "Ad Hoc Distributed Queries should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.xpcmdshelldisabled -Validation bool -Value $true -Initialize -Description "XP CmdShell should be disabled `$true or enabled `$false"
-Set-PSFConfig -Module dbachecks -Name policy.security.scanforstartupprocedures -Validation bool -Value $true -Initialize -Description "Scan For Startup Procedures should be disabled `$true or enabled `$false"
+Set-PSFConfig -Module dbachecks -Name policy.security.scanforstartupprocedures -Value 0 -Initialize -Description "Scan For Startup Procedures should be disabled 0 or enabled 1"
 
 #diskspce
 Set-PSFConfig -Module dbachecks -Name policy.diskspace.percentfree -Value 20 -Initialize -Description "Percent disk free"

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -625,18 +625,18 @@ Describe "Checking Instance.Tests.ps1 checks" -Tag UnitTest {
         # Define test cases for the results to fail test and fill expected message
         # This one is different from the others as we are checking for disabled !!
         # So the results of SPConfigure is 1, we expect $true but the result is false and the results of SPConfigure is 0, we expect $false but the result is true
-        $TestCases = @{spconfig = 1; expected = $true; actual = $false}, @{spconfig = 0; expected = $false; actual = $true}
+        $TestCases = @{spconfig = 1; expected = 1; actual = 0}, @{spconfig = 0; expected = 0; actual = 1}
         It "Fails Check Correctly for Config <spconfig> and expected value <expected>" -TestCases $TestCases {
             Param($spconfig, $actual, $expected)
             Mock Get-DbaSpConfigure {@{"ConfiguredValue" = $spconfig}}
-            {Assert-ScanForStartupProceduresDisabled -SQLInstance 'Dummy' -ScanForStartupProceduresDisabled $expected} | Should -Throw -ExpectedMessage "Expected `$$expected, because The Scan For Startup Procedures setting should be set correctly, but got `$$actual"
+            {Assert-ScanForStartupProcedures -AllInstanceInfo  -SQLInstance 'Dummy' -ScanForStartupProcedures $expected} | Should -Throw -ExpectedMessage "Expected `$$expected, because The Scan For Startup Procedures setting should be set correctly, but got `$$actual"
         }
         # again this one is different from the others as we are checking for disabled
-        $TestCases = @{spconfig = 1; expected = $false}, @{spconfig = 0; expected = $true; }
+        $TestCases = @{spconfig = 1; expected = 0}, @{spconfig = 0; expected = 1; }
         It "Passes Check Correctly for Config <spconfig> and expected value <expected>" -TestCases $TestCases {
             Param($spconfig, $expected)
             Mock Get-DbaSpConfigure {@{"ConfiguredValue" = $spconfig}}
-            Assert-ScanForStartupProceduresDisabled -SQLInstance 'Dummy' -ScanForStartupProceduresDisabled $expected
+            Assert-ScanForStartupProcedures -SQLInstance 'Dummy' -ScanForStartupProcedures $expected
         }
         # Validate we have called the mock the correct number of times
         It "Should call the mocks" {

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -717,7 +717,7 @@ InModuleScope dbachecks {
             It "Should pass the test successfully when default trace is enabled" {
                 # Mock for success
                 Mock Get-AllInstanceInfo {}
-                Assert-ErrorLogEntry -AllInstanceInfo (Get-AllInstanceInfo)
+                Assert-DefaultTrace -AllInstanceInfo (Get-AllInstanceInfo)
             }
             
             It "Should fail the test successfully when when default trace is not enabled" {
@@ -735,17 +735,17 @@ InModuleScope dbachecks {
             It "Should pass the test successfully when scan for startup procedures is disabled" {
                 # Mock for success
                 Mock Get-AllInstanceInfo {}
-                Assert-ScanForStoredProcedures -AllInstanceInfo (Get-AllInstanceInfo)
+                Assert-ScanForStartupProcedures -AllInstanceInfo (Get-AllInstanceInfo)
             }
             
             It "Should fail the test successfully when when scan for startup procedures is enabled" {
                 # Mock for failing test
                 Mock Get-AllInstanceInfo {[PSCustomObject]@{
-                    ScanForStartupProcedures = [PSCustomObject]@{
+                    ScanForStartupProceduresDisabled = [PSCustomObject]@{
                             ConfiguredValue = 1
                         }
                     }}
-                {Assert-ScanForStoredProcedures -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0, because We expect the Scan For Startup Procedures to be 0 but got 1."
+                {Assert-ScanForStartupProcedures -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0, because we expect the Scan For Startup Procedures to be 0 but got 1."
             }
         }
         Context "Checking Max Dump Entries" {

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -619,6 +619,35 @@ Describe "Checking Instance.Tests.ps1 checks" -Tag UnitTest {
             Assert-MockCalled @assertMockParams
         }
     }
+    Context "Checking Scan For Startup Procedures is disabled" {
+        # Mock the version check for running tests
+        Mock Connect-DbaInstance {}
+        # Define test cases for the results to fail test and fill expected message
+        # This one is different from the others as we are checking for disabled !!
+        # So the results of SPConfigure is 1, we expect $true but the result is false and the results of SPConfigure is 0, we expect $false but the result is true
+        $TestCases = @{spconfig = 1; expected = $true; actual = $false}, @{spconfig = 0; expected = $false; actual = $true}
+        It "Fails Check Correctly for Config <spconfig> and expected value <expected>" -TestCases $TestCases {
+            Param($spconfig, $actual, $expected)
+            Mock Get-DbaSpConfigure {@{"ConfiguredValue" = $spconfig}}
+            {Assert-ScanForStartupProceduresDisabled -SQLInstance 'Dummy' -ScanForStartupProceduresDisabled $expected} | Should -Throw -ExpectedMessage "Expected `$$expected, because The Scan For Startup Procedures setting should be set correctly, but got `$$actual"
+        }
+        # again this one is different from the others as we are checking for disabled
+        $TestCases = @{spconfig = 1; expected = $false}, @{spconfig = 0; expected = $true; }
+        It "Passes Check Correctly for Config <spconfig> and expected value <expected>" -TestCases $TestCases {
+            Param($spconfig, $expected)
+            Mock Get-DbaSpConfigure {@{"ConfiguredValue" = $spconfig}}
+            Assert-ScanForStartupProceduresDisabled -SQLInstance 'Dummy' -ScanForStartupProceduresDisabled $expected
+        }
+        # Validate we have called the mock the correct number of times
+        It "Should call the mocks" {
+            $assertMockParams = @{
+                'CommandName' = 'Get-DbaSpConfigure'
+                'Times'       = 4
+                'Exactly'     = $true
+            }
+            Assert-MockCalled @assertMockParams
+        }
+    }
     Context "Checking ErrorLog Count" {
         # if configured value is 30 and test value 30 it will pass
         It "Passes Check Correctly with the number of error log files set to 30" {

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -735,17 +735,17 @@ InModuleScope dbachecks {
             It "Should pass the test successfully when scan for startup procedures is disabled" {
                 # Mock for success
                 Mock Get-AllInstanceInfo {}
-                Assert-ErrorLogEntry -AllInstanceInfo (Get-AllInstanceInfo)
+                Assert-ScanForStoredProcedures -AllInstanceInfo (Get-AllInstanceInfo)
             }
             
-            It "Should fail the test successfully when when default trace is enabled" {
+            It "Should fail the test successfully when when scan for startup procedures is enabled" {
                 # Mock for failing test
                 Mock Get-AllInstanceInfo {[PSCustomObject]@{
-                        DefaultTrace = [PSCustomObject]@{
+                    ScanForStartupProcedures = [PSCustomObject]@{
                             ConfiguredValue = 1
                         }
                     }}
-                {Assert-ScanForStoredProcedures -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0, because We expect the Scan For Startup Procedures to be enabled but got, but got 1."
+                {Assert-ScanForStoredProcedures -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0, because We expect the Scan For Startup Procedures to be 0 but got 1."
             }
         }
         Context "Checking Max Dump Entries" {


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings
A CIS related check for seeing if Scan for Startup Procs is disabled.

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)