### PR TITLE
#330 default path checks

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -196,6 +196,30 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
     }
 
+    Describe "Default File Paths" -Tags DefaultFilePaths, $filename {
+        if ($NotContactable -contains $psitem) {
+            Context "Testing Default File Paths on $psitem" {
+                It "Can't Connect to $Psitem" {
+                    $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
+                }
+            }
+        }
+        else {
+            Context "Testing Default Data File Path on $psitem" {
+                It "Default Data File Paths on $psitem" {
+                    $diskFile = Get-DbaInstanceProperty -SqlInstance localhost\dev2016 | Where-Object Name -eq DefaultFile
+                    $diskFile.Value.substring(0,1) | Should -Not -Be "C" -Because 'Data files should not be on your C:\ drive'
+                }
+            }
+            Context "Testing Default Log File Path on $psitem" {
+                It "Default Log File Paths on $psitem" {
+                    $diskLog = Get-DbaInstanceProperty -SqlInstance localhost\dev2016 | Where-Object Name -eq DefaultLog
+                    $diskLog.Value.substring(0,1) | Should -Not -Be "C" -Because 'Log files should not be on your C:\ drive'
+                }
+            }
+        }
+    }
+
     Describe "Dedicated Administrator Connection" -Tags DAC, CIS, Low, $filename {
         $dac = Get-DbcConfigValue policy.dacallowed
         if ($NotContactable -contains $psitem) {

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -207,13 +207,13 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         else {
             Context "Testing Default Data File Path on $psitem" {
                 It "Default Data File Paths on $psitem" {
-                    $diskFile = Get-DbaInstanceProperty -SqlInstance localhost\dev2016 | Where-Object Name -eq DefaultFile
+                    $diskFile = Get-DbaInstanceProperty -SqlInstance $psitem | Where-Object Name -eq DefaultFile
                     $diskFile.Value.substring(0,1) | Should -Not -Be "C" -Because 'Default Data file path should not be your C:\ drive'
                 }
             }
             Context "Testing Default Log File Path on $psitem" {
                 It "Default Log File Paths on $psitem" {
-                    $diskLog = Get-DbaInstanceProperty -SqlInstance localhost\dev2016 | Where-Object Name -eq DefaultLog
+                    $diskLog = Get-DbaInstanceProperty -SqlInstance $psitem | Where-Object Name -eq DefaultLog
                     $diskLog.Value.substring(0,1) | Should -Not -Be "C" -Because 'Dafault Log file path should not be your C:\ drive'
                 }
             }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -214,7 +214,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             Context "Testing Default Log File Path on $psitem" {
                 It "Default Log File Paths on $psitem" {
                     $diskLog = Get-DbaInstanceProperty -SqlInstance localhost\dev2016 | Where-Object Name -eq DefaultLog
-                    $diskLog.Value.substring(0,1) | Should -Not -Be "C" -Because 'Dafult Log file path should not be your C:\ drive'
+                    $diskLog.Value.substring(0,1) | Should -Not -Be "C" -Because 'Dafault Log file path should not be your C:\ drive'
                 }
             }
         }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -208,13 +208,13 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             Context "Testing Default Data File Path on $psitem" {
                 It "Default Data File Paths on $psitem" {
                     $diskFile = Get-DbaInstanceProperty -SqlInstance localhost\dev2016 | Where-Object Name -eq DefaultFile
-                    $diskFile.Value.substring(0,1) | Should -Not -Be "C" -Because 'Data files should not be on your C:\ drive'
+                    $diskFile.Value.substring(0,1) | Should -Not -Be "C" -Because 'Default Data file path should not be your C:\ drive'
                 }
             }
             Context "Testing Default Log File Path on $psitem" {
                 It "Default Log File Paths on $psitem" {
                     $diskLog = Get-DbaInstanceProperty -SqlInstance localhost\dev2016 | Where-Object Name -eq DefaultLog
-                    $diskLog.Value.substring(0,1) | Should -Not -Be "C" -Because 'Log files should not be on your C:\ drive'
+                    $diskLog.Value.substring(0,1) | Should -Not -Be "C" -Because 'Dafult Log file path should not be your C:\ drive'
                 }
             }
         }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -196,9 +196,9 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
     }
 
-    Describe "Default File Paths" -Tags DefaultFilePaths, $filename {
+    Describe "Default File Path" -Tags DefaultFilePath, $filename {
         if ($NotContactable -contains $psitem) {
-            Context "Testing Default File Paths on $psitem" {
+            Context "Testing Default File Path on $psitem" {
                 It "Can't Connect to $Psitem" {
                     $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
                 }
@@ -206,13 +206,13 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
         else {
             Context "Testing Default Data File Path on $psitem" {
-                It "Default Data File Paths on $psitem" {
+                It "Default Data File Path on $psitem" {
                     $diskFile = Get-DbaInstanceProperty -SqlInstance $psitem | Where-Object Name -eq DefaultFile
                     $diskFile.Value.substring(0,1) | Should -Not -Be "C" -Because 'Default Data file path should not be your C:\ drive'
                 }
             }
             Context "Testing Default Log File Path on $psitem" {
-                It "Default Log File Paths on $psitem" {
+                It "Default Log File Path on $psitem" {
                     $diskLog = Get-DbaInstanceProperty -SqlInstance $psitem | Where-Object Name -eq DefaultLog
                     $diskLog.Value.substring(0,1) | Should -Not -Be "C" -Because 'Dafault Log file path should not be your C:\ drive'
                 }

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -4,7 +4,7 @@
         "Description": "Tests that the SQL Agent Account is running and set to automatic"
     },
     {
-        "UniqueTag": "Default File Path",
+        "UniqueTag": "DefaultFilePath",
         "Description": "Tests that the default file path for an instance is not the C drive"
     },
     {

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -4,10 +4,6 @@
         "Description": "Tests that the SQL Agent Account is running and set to automatic"
     },
     {
-        "UniqueTag": "DefaultFilePath",
-        "Description": "Tests that the default file path for an instance is not the C drive"
-    },
-    {
         "UniqueTag": "DbaOperator",
         "Description": "Tests that the specified (default blank) DBA Operators exist and have the correct email address"
     },
@@ -398,6 +394,10 @@
     {
         "UniqueTag": "DatabaseMailEnabled",
         "Description": "Tests that the Database Mail XPs configuration setting is set as specified (default false)"
+    },
+    {
+        "UniqueTag": "DefaultFilePath",
+        "Description": "Tests that the default file path for an instance is not the C drive"
     },
     {
         "UniqueTag": "AdHocDistributedQueriesEnabled",

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -4,6 +4,10 @@
         "Description": "Tests that the SQL Agent Account is running and set to automatic"
     },
     {
+        "UniqueTag": "Default File Path",
+        "Description": "Tests that the default file path for an instance is not the C drive"
+    },
+    {
         "UniqueTag": "DbaOperator",
         "Description": "Tests that the specified (default blank) DBA Operators exist and have the correct email address"
     },


### PR DESCRIPTION
Addresses #330

No failing tests.

Added a basic check, are the default file paths set as the C:\ drive? Because... they should not be.