### PR TITLE
Issue 649 - Check for OLE Automation Proecedues to be disabled - CIS

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -487,23 +487,6 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             Write-Warning "You need to use Set-DbcConfig -Name policy.xevent.validrunningsession -Value to add some Extended Events session names to run this check"
         }
     }
-    Describe "OLE Automation" -Tags OLEAutomation, security, CIS, Medium, $filename {
-        $OLEAutomation = Get-DbcConfigValue policy.oleautomation
-        if ($NotContactable -contains $psitem) {
-            Context "Testing OLE Automation on $psitem" {
-                It "Can't Connect to $Psitem" {
-                    $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
-                }
-            }
-        }
-        else {
-            Context "Testing OLE Automation on $psitem" {
-                It "OLE Automation is set to $OLEAutomation on $psitem" {
-                    (Get-DbaSpConfigure -SqlInstance $psitem -ConfigName 'OleAutomationProceduresEnabled').ConfiguredValue -eq 1 | Should -Be $OLEAutomation -Because 'OLE Automation can introduce additional security risks'
-                }
-            }
-        }
-    }
 
     Describe "sp_whoisactive is Installed" -Tags WhoIsActiveInstalled, Low, $filename {
         $db = Get-DbcConfigValue policy.whoisactive.database
@@ -815,8 +798,8 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
-    Describe "OLE Automation Procedures" -Tags OLEAutomationProcedures, CIS, Low, $filename {
-        $skip = Get-DbcConfigValue skip.instance.oleautomationprocedures
+    Describe "OLE Automation Procedures Disabled" -Tags OLEAutomationProceduresDisabled, CIS, Low, $filename {
+        $skip = Get-DbcConfigValue skip.instance.oleautomationproceduresdisabled
         if ($NotContactable -contains $psitem) {
             Context "Checking OLE Automation Procedures on $psitem" {
                 It "Can't Connect to $Psitem" -Skip:$skip {

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -815,6 +815,23 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
+    Describe "OLE Automation Procedures" -Tags OLEAutomationProcedures, CIS, Low, $filename {
+        $skip = Get-DbcConfigValue skip.instance.oleautomationprocedures
+        if ($NotContactable -contains $psitem) {
+            Context "Checking OLE Automation Procedures on $psitem" {
+                It "Can't Connect to $Psitem" -Skip:$skip {
+                    $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
+                }
+            }
+        }
+        else {
+            Context "Checking OLE Automation Procedures on $psitem" {
+                It "The OLE Automation Procedures should be disabled on $psitem"  -Skip:$skip {
+                    Assert-OLEAutomationProcedures -AllInstanceInfo $AllInstanceInfo
+                }
+            }
+        }
+    }
 }
 
 Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, High, $filename {

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -167,7 +167,7 @@ function Get-AllInstanceInfo {
                 }
                 catch {
                     $There = $false
-                    $OleAutomationProceduresDisabled = = [pscustomobject] @{
+                    $OleAutomationProceduresDisabled = [pscustomobject] @{
                         ConfiguredValue = 'We Could not Connect to $Instance'
                 }
             }

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -157,24 +157,24 @@ function Get-AllInstanceInfo {
             }
         }
 
-        'OleAutomationProcedures' {
+        'OleAutomationProceduresDisabled' {
             if ($There) {
                 try {
                     $SpConfig = Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'OleAutomationProceduresEnabled'
-                    $OleAutomationProcedures = [pscustomobject] @{
+                    $OleAutomationProceduresDisabled = [pscustomobject] @{
                         ConfiguredValue = $SpConfig.ConfiguredValue
                     }
                 }
                 catch {
                     $There = $false
-                    $OleAutomationProcedures = [pscustomobject] @{
+                    $OleAutomationProceduresDisabled = [pscustomobject] @{
                             ConfiguredValue = 'We Could not Connect to $Instance'
                     }
                 }
             }
             else {
                 $There = $false
-                $OleAutomationProcedures = [pscustomobject] @{
+                $OleAutomationProceduresDisabled = [pscustomobject] @{
                         ConfiguredValue = 'We Could not Connect to $Instance'
                     }
             }
@@ -209,7 +209,7 @@ function Get-AllInstanceInfo {
         ErrorLog = $ErrorLog
         DefaultTrace = $DefaultTrace
         MaxDump = $MaxDump
-        OleAutomationProcedures = $OleAutomationProcedures
+        OleAutomationProceduresDisabled = $OleAutomationProceduresDisabled
     }
 }
 
@@ -220,7 +220,7 @@ function Assert-DefaultTrace {
 
 function Assert-OleAutomationProcedures {
     Param($AllInstanceInfo)
-    $AllInstanceInfo.OleAutomationProcedures.ConfiguredValue | Should -Be 0 -Because "We expect the OLE Automation Procedures to be enabled but got $($AllInstanceInfo.OleAutomationProcedures.ConfiguredValue)"
+    $AllInstanceInfo.OleAutomationProceduresDisabled.ConfiguredValue | Should -Be 0 -Because "We expect the OLE Automation Procedures to be enabled but got $($AllInstanceInfo.OleAutomationProceduresDisabled.ConfiguredValue)"
 }
 function Assert-MaxDump {
     Param($AllInstanceInfo,$maxdumps)

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -267,7 +267,7 @@ function Assert-DefaultTrace {
 
 function Assert-OleAutomationProcedures {
     Param($AllInstanceInfo)
-    $AllInstanceInfo.OleAutomationProceduresDisabled.ConfiguredValue | Should -Be 0 -Because "We expect the OLE Automation Procedures to be disabled but got $($AllInstanceInfo.OleAutomationProceduresDisabled.ConfiguredValue)"
+    $AllInstanceInfo.OleAutomationProceduresDisabled.ConfiguredValue | Should -Be 0 -Because "We expect the OLE Automation Procedures to be disabled"
 }
     function Assert-ScanForStartupProcedures {
     param ($AllInstanceInfo)

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -157,6 +157,29 @@ function Get-AllInstanceInfo {
             }
         }
 
+        'OleAutomationProcedures' {
+            if ($There) {
+                try {
+                    $SpConfig = Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'OleAutomationProceduresEnabled'
+                    $OleAutomationProcedures = [pscustomobject] @{
+                        ConfiguredValue = $SpConfig.ConfiguredValue
+                    }
+                }
+                catch {
+                    $There = $false
+                    $OleAutomationProcedures = [pscustomobject] @{
+                            ConfiguredValue = 'We Could not Connect to $Instance'
+                    }
+                }
+            }
+            else {
+                $There = $false
+                $OleAutomationProcedures = [pscustomobject] @{
+                        ConfiguredValue = 'We Could not Connect to $Instance'
+                    }
+            }
+        }
+
         'MemoryDump' {
             if ($There) {
                 try {
@@ -186,6 +209,7 @@ function Get-AllInstanceInfo {
         ErrorLog = $ErrorLog
         DefaultTrace = $DefaultTrace
         MaxDump = $MaxDump
+        OleAutomationProcedures = $OleAutomationProcedures
     }
 }
 
@@ -194,6 +218,10 @@ function Assert-DefaultTrace {
     $AllInstanceInfo.DefaultTrace.ConfiguredValue | Should -Be 1 -Because "We expect the Default Trace to be enabled but got $($AllInstanceInfo.DefaultTrace.Trace.ConfiguredValue)"
 }
 
+function Assert-OleAutomationProcedures {
+    Param($AllInstanceInfo)
+    $AllInstanceInfo.OleAutomationProcedures.ConfiguredValue | Should -Be 0 -Because "We expect the OLE Automation Procedures to be enabled but got $($AllInstanceInfo.OleAutomationProcedures.ConfiguredValue)"
+}
 function Assert-MaxDump {
     Param($AllInstanceInfo,$maxdumps)
     $AllInstanceInfo.MaxDump.Count | Should -BeLessThan $maxdumps -Because "We expected less than $maxdumps dumps but found $($AllInstanceInfo.MaxDump.Count). Memory dumps often suggest issues with the SQL Server instance"

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -220,7 +220,7 @@ function Assert-DefaultTrace {
 
 function Assert-OleAutomationProcedures {
     Param($AllInstanceInfo)
-    $AllInstanceInfo.OleAutomationProceduresDisabled.ConfiguredValue | Should -Be 0 -Because "We expect the OLE Automation Procedures to be enabled but got $($AllInstanceInfo.OleAutomationProceduresDisabled.ConfiguredValue)"
+    $AllInstanceInfo.OleAutomationProceduresDisabled.ConfiguredValue | Should -Be 0 -Because "We expect the OLE Automation Procedures to be disabled but got $($AllInstanceInfo.OleAutomationProceduresDisabled.ConfiguredValue)"
 }
 function Assert-MaxDump {
     Param($AllInstanceInfo,$maxdumps)

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -404,6 +404,10 @@
         "Description": "Tests that the XP CmdShell configuration setting is set as specified (default true - meaning it should be disabled)"
     },
     {
+        "UniqueTag": "OLEAutomationProcedures",
+        "Description": "Tests that the OLE Automation Procedures configuration setting is set as specified (default 0 - meaning it should be disabled)"
+    },
+    {
         "UniqueTag": "JobHistory",
         "Description": "Tests that the job history configuration for max number of rows in the whole agent log is greater than or equal to the specified value (default 1000) and that the max number of rows per job configuration is greater than or equal to the specified value (default 100) ."
     },

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -404,7 +404,7 @@
         "Description": "Tests that the XP CmdShell configuration setting is set as specified (default true - meaning it should be disabled)"
     },
     {
-        "UniqueTag": "OLEAutomationProcedures",
+        "UniqueTag": "OLEAutomationProceduresDisabled",
         "Description": "Tests that the OLE Automation Procedures configuration setting is set as specified (default 0 - meaning it should be disabled)"
     },
     {

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -54,6 +54,7 @@ Set-PSFConfig -Module dbachecks -Name policy.security.crossdbownershipchaining -
 Set-PSFConfig -Module dbachecks -Name policy.security.databasemailenabled -Validation bool -Value $false -Initialize -Description "Database Mail XPs should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.adhocdistributedqueriesenabled -Validation bool -Value $false -Initialize -Description "Ad Hoc Distributed Queries should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.xpcmdshelldisabled -Validation bool -Value $true -Initialize -Description "XP CmdShell should be disabled `$true or enabled `$false"
+Set-PSFConfig -Module dbachecks -Name policy.security.oleautomationprocedures -Value 0 -Initialize -Description "OLE Automation Procedures should be 0 (disabled) or 1 (enabled)"
 
 #diskspce
 Set-PSFConfig -Module dbachecks -Name policy.diskspace.percentfree -Value 20 -Initialize -Description "Percent disk free"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -54,7 +54,7 @@ Set-PSFConfig -Module dbachecks -Name policy.security.crossdbownershipchaining -
 Set-PSFConfig -Module dbachecks -Name policy.security.databasemailenabled -Validation bool -Value $false -Initialize -Description "Database Mail XPs should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.adhocdistributedqueriesenabled -Validation bool -Value $false -Initialize -Description "Ad Hoc Distributed Queries should be enabled `$true or disabled `$false"
 Set-PSFConfig -Module dbachecks -Name policy.security.xpcmdshelldisabled -Validation bool -Value $true -Initialize -Description "XP CmdShell should be disabled `$true or enabled `$false"
-Set-PSFConfig -Module dbachecks -Name policy.security.oleautomationprocedures -Value 0 -Initialize -Description "OLE Automation Procedures should be 0 (disabled) or 1 (enabled)"
+Set-PSFConfig -Module dbachecks -Name policy.security.oleautomationproceduresdisabled -Validation bool -Value $true -Initialize -Description "OLE Automation Procedures should be disabled `$true or enabled `$false"
 
 #diskspce
 Set-PSFConfig -Module dbachecks -Name policy.diskspace.percentfree -Value 20 -Initialize -Description "Percent disk free"
@@ -225,7 +225,7 @@ Set-PSFConfig -Module dbachecks -Name skip.hadr.listener.pingcheck -Validation b
 Set-PSFConfig -Module dbachecks -Name skip.instance.defaulttrace -Validation bool -Value $false -Initialize -Description "Skip the default trace check"
 Set-PSFConfig -Module dbachecks -Name skip.agent.longrunningjobs -Validation bool -Value $false -Initialize -Description "Skip the long running agent jobs check"
 Set-PSFConfig -Module dbachecks -Name skip.agent.lastjobruntime -Validation bool -Value $false -Initialize -Description "Skip the last agent job time check"
-
+Set-PSFConfig -Module dbachecks -Name skip.instance.oleautomationproceduresdisabled -Validation bool -Value $false -Initialize -Description "Skip OLE Automation Procedures check"
 #agent
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatorname -Value $null -Initialize -Description "Name of the DBA Operator in SQL Agent"
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatoremail -Value $null -Initialize -Description "Email address of the DBA Operator in SQL Agent"

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -741,11 +741,11 @@ InModuleScope dbachecks {
             It "Should fail the test successfully when when OLE Automation Procedures is not enabled" {
                 # Mock for failing test
                 Mock Get-AllInstanceInfo {[PSCustomObject]@{
-                        OLEAutomationProcedures = [PSCustomObject]@{
+                        OLEAutomationProceduresDisabled = [PSCustomObject]@{
                             ConfiguredValue = 1
                         }
                     }}
-                {Assert-OLEAutomationProcedures -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0, because we expect the OLE Automation Procedures to be enabled, but got 1."
+                {Assert-OLEAutomationProcedures -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0 because we expect the OLE Automation Procedures to be disabled but got 1 (enabled)."
             }
         }
         Context "Checking Max Dump Entries" {

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -727,7 +727,25 @@ InModuleScope dbachecks {
                             ConfiguredValue = 0
                         }
                     }}
-                {Assert-DefaultTrace -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 1, because We expect the Default Trace to be enabled but got, but got 0."
+                {Assert-DefaultTrace -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 1, because We expect the Default Trace to be enabled, but got 0."
+            }
+        }
+        Context "Checking OLE Automation Procedures Entries" {
+           
+            It "Should pass the test successfully when OLE Automation Procedures is disabled" {
+                # Mock for success
+                Mock Get-AllInstanceInfo {}
+                Assert-OLEAutomationProcedures -AllInstanceInfo (Get-AllInstanceInfo)
+            }
+            
+            It "Should fail the test successfully when when OLE Automation Procedures is not enabled" {
+                # Mock for failing test
+                Mock Get-AllInstanceInfo {[PSCustomObject]@{
+                        OLEAutomationProcedures = [PSCustomObject]@{
+                            ConfiguredValue = 1
+                        }
+                    }}
+                {Assert-OLEAutomationProcedures -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0, because we expect the OLE Automation Procedures to be enabled, but got 1."
             }
         }
         Context "Checking Max Dump Entries" {

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -732,7 +732,7 @@ InModuleScope dbachecks {
                         }
                     }
                 }
-                {Assert-DefaultTrace -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 1, because We expect the Default Trace to be enabled, but got 0."
+                {Assert-DefaultTrace -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 1, because We expected the Default Trace to be enabled, but got 0."
             }
         }
         Context "Checking OLE Automation Procedures Entries" {

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -677,10 +677,9 @@ InModuleScope dbachecks {
             }
 
             It "Should return the correct results for Default Trace when it is enabled" {
-                Mock Get-DbaSpConfigure {[pscustomobject]@{
-                        ConfiguredValue = 1
+                Mock Get-DbaSpConfigure {@{
+                        'ConfiguredValue' = 1
                     }}
-           
                 (Get-AllInstanceInfo -Instance Dummy -Tags DefaultTrace -There $true).DefaultTrace.ConfiguredValue | Should -Be 1 -Because "We need to return one when we have default trace enabled"
             }
 
@@ -739,19 +738,26 @@ InModuleScope dbachecks {
            
             It "Should pass the test successfully when OLE Automation Procedures is disabled" {
                 # Mock for success
-                Mock Get-AllInstanceInfo {}
+                # This should pass when the configured value for OleAutomationProcedures enabled is 0 (ie disabled)
+                Mock Get-AllInstanceInfo {[PSCustomObject]@{
+                    OleAutomationProceduresDisabled = [PSCustomObject]@{
+                        ConfiguredValue = 0
+                    }
+                }
+            }
                 Assert-OLEAutomationProcedures -AllInstanceInfo (Get-AllInstanceInfo)
             }
             
-            It "Should fail the test successfully when when OLE Automation Procedures is not enabled" {
+            It "Should fail the test successfully when when OLE Automation Procedures is enabled" {
                 # Mock for failing test
+                # This should pass when the configured value for OleAutomationProcedures enabled is 1 (ie enabled)
                 Mock Get-AllInstanceInfo {[PSCustomObject]@{
-                        OLEAutomationProceduresDisabled = [PSCustomObject]@{
-                            ConfiguredValue = 1
-                        }
+                    OleAutomationProceduresDisabled = [PSCustomObject]@{
+                        ConfiguredValue = 1
                     }
                 }
-                {Assert-OLEAutomationProcedures -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0 because we expect the OLE Automation Procedures to be disabled but got 1 (enabled)."
+            }
+                {Assert-OLEAutomationProcedures -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0, because we expect the OLE Automation Procedures to be disabled, but got 1."
             }
         }
         Context "Checking Remote Access Entries" {


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings
Test for OLE Automation Procedures disabled.

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)