### PR TITLE
Fixmultitags

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,8 @@
 Thank you Tracey @tboggiano
     Added new CIS Check for OLE AUtomation Procedures to be disabled #707
     Moving the Cross DB Ownership Chaining check into the AllInstance check to help speed up checks #708
+Thank you Rob
+    Fixing the Tags so that they are picked up by AllInstanceInfo Fixes #715
 
 ##Latest
 

--- a/dbachecks.psd1
+++ b/dbachecks.psd1
@@ -135,7 +135,8 @@
 Thank you Tracey tboggiano
     Added new CIS Check for OLE AUtomation Procedures to be disabled #707
     Moving the Cross DB Ownership Chaining check into the AllInstance check to help speed up checks #708
-
+Thank you Rob
+    Fixing the Tags so that they are picked up by AllInstanceInfo Fixes #715
 ##Latest
 
 Run Get-DbcReleaseNotes for all release notes

--- a/functions/Get-DbcCheck.ps1
+++ b/functions/Get-DbcCheck.ps1
@@ -8,6 +8,9 @@
     .PARAMETER Pattern
         May be any string, supports wildcards.
 
+    .PARAMETER Group
+        To be able to filter by group
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -30,6 +33,7 @@ function Get-DbcCheck {
     [CmdletBinding()]
     param (
         [string]$Pattern,
+        [string]$Group,
         [switch]$EnableException
     )
    
@@ -42,9 +46,6 @@ function Get-DbcCheck {
                         $_.Group -match $Pattern -or $_.Description -match $Pattern -or
                         $_.UniqueTag -match $Pattern -or $_.AllTags -match $Pattern -or $_.Type -match $Pattern
                     }
-                    @($output).ForEach{
-                        Select-DefaultView -InputObject $psitem -TypeName Check -Property 'Group', 'Type', 'UniqueTag', 'AllTags', 'Config', 'Description'
-                    }
                 }
             }
             else {
@@ -53,17 +54,21 @@ function Get-DbcCheck {
                         $_.Group -like $Pattern -or $_.Description -like $Pattern -or
                         $_.UniqueTag -like $Pattern -or $_.AllTags -like $Pattern -or $_.Type -like $Pattern
                     }
-                    @($output).ForEach{
-                        Select-DefaultView -InputObject $psitem -TypeName Check -Property 'Group', 'Type', 'UniqueTag', 'AllTags' , 'Config', 'Description'
-                    }
                 }
             }
         }
         else {
             $output = Get-Content "$script:localapp\checks.json" | Out-String | ConvertFrom-Json
-            @($output).ForEach{
-                Select-DefaultView -InputObject $psitem -TypeName Check -Property 'Group', 'Type', 'UniqueTag', 'AllTags', 'Config', 'Description'
+        }
+        if ($Group) {
+            $output = @($output).ForEach{ 
+                $psitem | Where-Object {
+                    $_.Group -eq $Group
+                } 
             }
+        }
+        @($output).ForEach{
+            Select-DefaultView -InputObject $psitem -TypeName Check -Property 'Group', 'Type', 'UniqueTag', 'AllTags', 'Config', 'Description'
         }
     }
 }

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -304,7 +304,7 @@ function Assert-MaxDump {
 
 function Assert-RemoteAccess {
     param ($AllInstanceInfo)
-    $AllInstanceInfo.RemoteAccessDisabled.ConfiguredValue | Should -Be 0 -Because "We expected Remote Access to be disabled"
+    $AllInstanceInfo.RemoteAccess.ConfiguredValue | Should -Be 0 -Because "We expected Remote Access to be disabled"
 }
 
 function Assert-InstanceMaxDop {

--- a/internal/functions/Get-CheckInformation.ps1
+++ b/internal/functions/Get-CheckInformation.ps1
@@ -3,7 +3,7 @@ function Get-CheckInformation {
     Param($Group, $Check, $AllChecks ,$ExcludeCheck)
     ## need to reset the variable here
     $script:localapp = Get-DbcConfigValue -Name app.localapp
-    $GroupChecksConfig = (Get-DbcCheck).Where{$_.Group -eq $Group}
+    $GroupChecksConfig = Get-DbcCheck -Group $Group
     # Nothing if we exclude the group
     if ($ExcludeCheck -contains $Group) {Return}
     # Create an array of tags for the group except the Group Name
@@ -42,7 +42,7 @@ function Get-CheckInformation {
         @($Check).ForEach{
             if($GroupChecks -contains $psitem){
     ## BUT - This falls flat when you use a tag for a number of Checks that is not a group (like CIS) in that case all you get in $CheckInfo is CIS and not the relevant unique tags
-                (Get-DbcCheck $psitem).ForEach{
+                @(Get-DbcCheck -Pattern $psitem).ForEach{
                     $CheckInfo += $psitem.UniqueTag
                 } 
             }

--- a/internal/functions/Get-CheckInformation.ps1
+++ b/internal/functions/Get-CheckInformation.ps1
@@ -8,6 +8,7 @@ function Get-CheckInformation {
     if ($ExcludeCheck -contains $Group) {Return}
     # Create an array of tags for the group except the Group Name
     #It's a bit clubnky but it works
+    # This will create a list of all the tags for the group that has been specified ( so the instance checks or the database checks for example)
     $GroupChecks = @()
     @($GroupChecksConfig.AllTags).foreach{
         @($psitem.Split(',')).ForEach{
@@ -40,82 +41,12 @@ function Get-CheckInformation {
     else{
         @($Check).ForEach{
             if($GroupChecks -contains $psitem){
-                $CheckInfo += $psitem
+    ## BUT - This falls flat when you use a tag for a number of Checks that is not a group (like CIS) in that case all you get in $CheckInfo is CIS and not the relevant unique tags
+                (Get-DbcCheck $psitem).ForEach{
+                    $CheckInfo += $psitem.UniqueTag
+                } 
             }
         }
     }
     Return $CheckInfo 
 }
-
-# SIG # Begin signature block
-# MIINEAYJKoZIhvcNAQcCoIINATCCDP0CAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
-# gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR
-# AgEAAgEAAgEAAgEAAgEAMCEwCQYFKw4DAhoFAAQUOkgECV5AGvCwzwpKIDidk68g
-# 8ligggpSMIIFGjCCBAKgAwIBAgIQAsF1KHTVwoQxhSrYoGRpyjANBgkqhkiG9w0B
-# AQsFADByMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYD
-# VQQLExB3d3cuZGlnaWNlcnQuY29tMTEwLwYDVQQDEyhEaWdpQ2VydCBTSEEyIEFz
-# c3VyZWQgSUQgQ29kZSBTaWduaW5nIENBMB4XDTE3MDUwOTAwMDAwMFoXDTIwMDUx
-# MzEyMDAwMFowVzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMQ8wDQYD
-# VQQHEwZWaWVubmExETAPBgNVBAoTCGRiYXRvb2xzMREwDwYDVQQDEwhkYmF0b29s
-# czCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI8ng7JxnekL0AO4qQgt
-# Kr6p3q3SNOPh+SUZH+SyY8EA2I3wR7BMoT7rnZNolTwGjUXn7bRC6vISWg16N202
-# 1RBWdTGW2rVPBVLF4HA46jle4hcpEVquXdj3yGYa99ko1w2FOWzLjKvtLqj4tzOh
-# K7wa/Gbmv0Si/FU6oOmctzYMI0QXtEG7lR1HsJT5kywwmgcjyuiN28iBIhT6man0
-# Ib6xKDv40PblKq5c9AFVldXUGVeBJbLhcEAA1nSPSLGdc7j4J2SulGISYY7ocuX3
-# tkv01te72Mv2KkqqpfkLEAQjXgtM0hlgwuc8/A4if+I0YtboCMkVQuwBpbR9/6ys
-# Z+sCAwEAAaOCAcUwggHBMB8GA1UdIwQYMBaAFFrEuXsqCqOl6nEDwGD5LfZldQ5Y
-# MB0GA1UdDgQWBBRcxSkFqeA3vvHU0aq2mVpFRSOdmjAOBgNVHQ8BAf8EBAMCB4Aw
-# EwYDVR0lBAwwCgYIKwYBBQUHAwMwdwYDVR0fBHAwbjA1oDOgMYYvaHR0cDovL2Ny
-# bDMuZGlnaWNlcnQuY29tL3NoYTItYXNzdXJlZC1jcy1nMS5jcmwwNaAzoDGGL2h0
-# dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9zaGEyLWFzc3VyZWQtY3MtZzEuY3JsMEwG
-# A1UdIARFMEMwNwYJYIZIAYb9bAMBMCowKAYIKwYBBQUHAgEWHGh0dHBzOi8vd3d3
-# LmRpZ2ljZXJ0LmNvbS9DUFMwCAYGZ4EMAQQBMIGEBggrBgEFBQcBAQR4MHYwJAYI
-# KwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBOBggrBgEFBQcwAoZC
-# aHR0cDovL2NhY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0U0hBMkFzc3VyZWRJ
-# RENvZGVTaWduaW5nQ0EuY3J0MAwGA1UdEwEB/wQCMAAwDQYJKoZIhvcNAQELBQAD
-# ggEBANuBGTbzCRhgG0Th09J0m/qDqohWMx6ZOFKhMoKl8f/l6IwyDrkG48JBkWOA
-# QYXNAzvp3Ro7aGCNJKRAOcIjNKYef/PFRfFQvMe07nQIj78G8x0q44ZpOVCp9uVj
-# sLmIvsmF1dcYhOWs9BOG/Zp9augJUtlYpo4JW+iuZHCqjhKzIc74rEEiZd0hSm8M
-# asshvBUSB9e8do/7RhaKezvlciDaFBQvg5s0fICsEhULBRhoyVOiUKUcemprPiTD
-# xh3buBLuN0bBayjWmOMlkG1Z6i8DUvWlPGz9jiBT3ONBqxXfghXLL6n8PhfppBhn
-# daPQO8+SqF5rqrlyBPmRRaTz2GQwggUwMIIEGKADAgECAhAECRgbX9W7ZnVTQ7Vv
-# lVAIMA0GCSqGSIb3DQEBCwUAMGUxCzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxEaWdp
-# Q2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xJDAiBgNVBAMTG0Rp
-# Z2lDZXJ0IEFzc3VyZWQgSUQgUm9vdCBDQTAeFw0xMzEwMjIxMjAwMDBaFw0yODEw
-# MjIxMjAwMDBaMHIxCzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMx
-# GTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xMTAvBgNVBAMTKERpZ2lDZXJ0IFNI
-# QTIgQXNzdXJlZCBJRCBDb2RlIFNpZ25pbmcgQ0EwggEiMA0GCSqGSIb3DQEBAQUA
-# A4IBDwAwggEKAoIBAQD407Mcfw4Rr2d3B9MLMUkZz9D7RZmxOttE9X/lqJ3bMtdx
-# 6nadBS63j/qSQ8Cl+YnUNxnXtqrwnIal2CWsDnkoOn7p0WfTxvspJ8fTeyOU5JEj
-# lpB3gvmhhCNmElQzUHSxKCa7JGnCwlLyFGeKiUXULaGj6YgsIJWuHEqHCN8M9eJN
-# YBi+qsSyrnAxZjNxPqxwoqvOf+l8y5Kh5TsxHM/q8grkV7tKtel05iv+bMt+dDk2
-# DZDv5LVOpKnqagqrhPOsZ061xPeM0SAlI+sIZD5SlsHyDxL0xY4PwaLoLFH3c7y9
-# hbFig3NBggfkOItqcyDQD2RzPJ6fpjOp/RnfJZPRAgMBAAGjggHNMIIByTASBgNV
-# HRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBhjATBgNVHSUEDDAKBggrBgEF
-# BQcDAzB5BggrBgEFBQcBAQRtMGswJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRp
-# Z2ljZXJ0LmNvbTBDBggrBgEFBQcwAoY3aHR0cDovL2NhY2VydHMuZGlnaWNlcnQu
-# Y29tL0RpZ2lDZXJ0QXNzdXJlZElEUm9vdENBLmNydDCBgQYDVR0fBHoweDA6oDig
-# NoY0aHR0cDovL2NybDQuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0QXNzdXJlZElEUm9v
-# dENBLmNybDA6oDigNoY0aHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0
-# QXNzdXJlZElEUm9vdENBLmNybDBPBgNVHSAESDBGMDgGCmCGSAGG/WwAAgQwKjAo
-# BggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzAKBghghkgB
-# hv1sAzAdBgNVHQ4EFgQUWsS5eyoKo6XqcQPAYPkt9mV1DlgwHwYDVR0jBBgwFoAU
-# Reuir/SSy4IxLVGLp6chnfNtyA8wDQYJKoZIhvcNAQELBQADggEBAD7sDVoks/Mi
-# 0RXILHwlKXaoHV0cLToaxO8wYdd+C2D9wz0PxK+L/e8q3yBVN7Dh9tGSdQ9RtG6l
-# jlriXiSBThCk7j9xjmMOE0ut119EefM2FAaK95xGTlz/kLEbBw6RFfu6r7VRwo0k
-# riTGxycqoSkoGjpxKAI8LpGjwCUR4pwUR6F6aGivm6dcIFzZcbEMj7uo+MUSaJ/P
-# QMtARKUT8OZkDCUIQjKyNookAv4vcn4c10lFluhZHen6dGRrsutmQ9qzsIzV6Q3d
-# 9gEgzpkxYz0IGhizgZtPxpMQBvwHgfqL2vmCSfdibqFT+hKUGIUukpHqaGxEMrJm
-# oecYpJpkUe8xggIoMIICJAIBATCBhjByMQswCQYDVQQGEwJVUzEVMBMGA1UEChMM
-# RGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMTEwLwYDVQQD
-# EyhEaWdpQ2VydCBTSEEyIEFzc3VyZWQgSUQgQ29kZSBTaWduaW5nIENBAhACwXUo
-# dNXChDGFKtigZGnKMAkGBSsOAwIaBQCgeDAYBgorBgEEAYI3AgEMMQowCKACgACh
-# AoAAMBkGCSqGSIb3DQEJAzEMBgorBgEEAYI3AgEEMBwGCisGAQQBgjcCAQsxDjAM
-# BgorBgEEAYI3AgEVMCMGCSqGSIb3DQEJBDEWBBSZP6fmUPlBBkNTLJoQl+74k94Y
-# ojANBgkqhkiG9w0BAQEFAASCAQA5xVDr67dw13AANEsqIGrSLxCBEjPqQEf0NhvY
-# pJykkvWGIRqxih9soqbNtThgZACKVSz8P2ZGs84bIsgSJZ+qln92a9PemamAcXIb
-# aqdY3ilv4Oxl93lOCmIlvV4F6UpX9VWiwSIdamxEQL8qAZhQ23x1oaa/vy+DbHNG
-# Nal8mOeptCE7OLObCgT1kqniTnRloHPvBJcOplLFElTrBHfxFpuhl2AmGZHYnFKw
-# Hsv/9qOKcuiA1twpuEF6v/1PKvzLAK4pYUkQRib5Taqwp2rw8QLuMDlsbYjjDqZ6
-# YHT0oNMiY1rhfThkWtOfvAzWfWTuHzuXe63zezrz+ugAn67J
-# SIG # End signature block

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -760,7 +760,7 @@ InModuleScope dbachecks {
             It "Should pass the test successfully when remote access is disabled" {
                 # Mock for success
                 Mock Get-AllInstanceInfo {[PSCustomObject]@{
-                    RemoteAccessDisabled = [PSCustomObject]@{
+                    RemoteAccess = [PSCustomObject]@{
                         ConfiguredValue = 0
                     }
                 }
@@ -771,7 +771,7 @@ InModuleScope dbachecks {
             It "Should fail the test successfully when remote access is enabled" {
                 # Mock for failing test
                 Mock Get-AllInstanceInfo {[PSCustomObject]@{
-                        RemoteAccessDisabled = [PSCustomObject]@{
+                        RemoteAccess = [PSCustomObject]@{
                             ConfiguredValue = 1
                         }
                     }

--- a/tests/functions/Get-CheckInformation.tests.ps1
+++ b/tests/functions/Get-CheckInformation.tests.ps1
@@ -19,7 +19,7 @@ Describe "Testing Get-CheckInformation" -Tag Get-CheckInformation, Unittest {
     }
     Context "Output" {
         $results = (Get-Content $ModuleBase\get-check.json) -join "`n"| ConvertFrom-Json
-        Mock Get-DbcCheck {$results}
+        Mock Get-DbcCheck {$results.Where{$_.Group -eq $Group}} -ParameterFilter {$Group -and $Group -in ('Server','Database')}
         It "Should Return All of the checks for a group when the Check equals the group and nothing excluded" {
             Get-CheckInformation -Group Server -Check Server | Should -Be 'PowerPlan', 'InstanceConnection', 'Connectivity', 'SPN', 'DiskCapacity', 'Storage', 'DISA', 'PingComputer', 'CPUPrioritisation', 'DiskAllocationUnit' -Because 'When the Check is specified and is a group it should return all of the tags for that group and not the groupname if nothing is exclueded'
         }
@@ -32,11 +32,11 @@ Describe "Testing Get-CheckInformation" -Tag Get-CheckInformation, Unittest {
         It "Should Return two checks for a group when two unique tags are specified and nothing excluded" {
             Get-CheckInformation -Group Server -Check SPN,InstanceConnection | Should -Be  'SPN', 'InstanceConnection' -Because 'When a Check is specified it should return just that check'
         }
-        It "Should return a none-unique tag if a none-unique tag is specified and nothing is excluded"{
-            Get-CheckInformation -Group Database -Check LastBackup | Should -Be 'LastBackup' -Because 'When a none-unique tag is specified it should return just that tag'
+        It "Should return a the unique tags for the none-unique tag if a none-unique tag is specified and nothing is excluded"{
+            Get-CheckInformation -Group Database -Check LastBackup | Should -Be 'TestLastBackup', 'TestLastBackupVerifyOnly', 'LastFullBackup', 'LastDiffBackup', 'LastLogBackup' -Because 'When a none-unique tag is specified it should return all of the unique tags'
         }
-        It "Should return two none-unique tags if two none-unique tags are specified and nothing is excluded"{
-            Get-CheckInformation -Group Database -Check LastBackup, DISA | Should -Be 'LastBackup','DISA' -Because 'When a none-unique tag is specified it should return just that tag'
+        It "Should return the unique tags for the none-unique tags if two none-unique tags are specified and nothing is excluded"{
+            Get-CheckInformation -Group Database -Check LastBackup, MaxDop  | Should -Be 'TestLastBackup', 'TestLastBackupVerifyOnly', 'LastFullBackup', 'LastDiffBackup', 'LastLogBackup', 'MaxDopDatabase', 'MaxDopInstance' -Because 'When a none-unique tag is specified it should return all of the unique tags'
         }
         It "Should Return All of the checks for a group except the excluded ones when the Check equals the group and one check is excluded" {
             Get-CheckInformation -Group Server -Check Server -ExcludeCheck PowerPlan | Should -Be  'InstanceConnection', 'Connectivity', 'SPN', 'DiskCapacity', 'Storage', 'DISA', 'PingComputer', 'CPUPrioritisation', 'DiskAllocationUnit' -Because 'When the Check is specified and is a group it should return all of the tags for that group except the excluded one and not the groupname'


### PR DESCRIPTION
Annoyingly adding functionality breaks things :-)

So #715 is because of the way that Get-CheckInformation parses the params to gather the tags which Get-AllInstanceINfo uses to go gather info

fixing that made the mocks for the tests fail to work as expected so I added a a group param to Get-DbcCheck

Remote Access was using the wrong propertyname