### PR TITLE
CIS Login tests

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -1036,16 +1036,34 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
     Describe "Login Password Expiration" -Tags LoginPasswordExpiration, Security, CIS, Medium, $filename {
         $skip = Get-DbcConfigValue skip.security.LoginPasswordExpiration
         if ($NotContactable -contains $psitem) {
-            Context "Testing if the login password expiratin is enabeld for sql logins in the sysadmin role $psitem" {
+            Context "Testing if the login password expiration is enabled for sql logins in the sysadmin role $psitem" {
                 It "Can't Connect to $Psitem" -Skip:$skip {
                     $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
                 }
             }
         }
         else {
-            Context "Testing if the login password expiratin is enabeld for sql logins in the sysadmin role on $psitem" {
+            Context "Testing if the login password expiration is enabled for sql logins in the sysadmin role on $psitem" {
                 It "All sql logins should have the password expiration option set to ON in the sysadmin role on $psitem" -Skip:$skip {
                     Assert-LoginPasswordExpiration -AllInstanceInfo $AllInstanceInfo
+                }
+            }
+        }
+    }
+
+    Describe "Login Must Change" -Tags LoginMustChange, Security, CIS, Medium, $filename {
+        $skip = Get-DbcConfigValue skip.security.LoginMustChange
+        if ($NotContactable -contains $psitem) {
+            Context "Testing if the new SQL logins that have not logged have to change their password when they log in on $psitem" {
+                It "Can't Connect to $Psitem" -Skip:$skip {
+                    $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
+                }
+            }
+        }
+        else {
+            Context "Testing if the new SQL logins that have not logged have to change their password when they log in on $psitem" {
+                It "All new sql logins should have the have to change their password when they log in for the first time on $psitem" {
+                    Assert-LoginMustChange -AllInstanceInfo $AllInstanceInfo
                 }
             }
         }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -1061,7 +1061,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
         else {
-            Context "Testing if the new SQL logins that have not logged have to change their password when they log in on $psitem" {
+            Context "Testing if the new SQL logins that have not logged have to change their password when they log in on $psitem" -Skip:$skip {
                 It "All new sql logins should have the have to change their password when they log in for the first time on $psitem" {
                     Assert-LoginMustChange -AllInstanceInfo $AllInstanceInfo
                 }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -1014,6 +1014,24 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
+
+    Describe "Login Check Policy" -Tags LoginCheckPolicy, Security, CIS, Medium, $filename {
+        $skip = Get-DbcConfigValue skip.security.LoginCheckPolicy
+        if ($NotContactable -contains $psitem) {
+            Context "Testing if the CHECK_POLICY is enabled on all logins on $psitem" {
+                It "Can't Connect to $Psitem" -Skip:$skip {
+                    $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
+                }
+            }
+        }
+        else {
+            Context "Testing if the CHECK_POLICY is enabled on all logins on $psitem" {
+                It "All logins should have the CHECK_POLICY option set to ON on $psitem" {
+                    Assert-LoginCheckPolicy -AllInstanceInfo $AllInstanceInfo
+                }
+            }
+        }
+    }
 }
 
 Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, High, $filename {

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -1032,6 +1032,24 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
+
+    Describe "Login Password Expiration" -Tags LoginPasswordExpiration, Security, CIS, Medium, $filename {
+        $skip = Get-DbcConfigValue skip.security.LoginPasswordExpiration
+        if ($NotContactable -contains $psitem) {
+            Context "Testing if the login password expiratin is enabeld for sql logins in the sysadmin role $psitem" {
+                It "Can't Connect to $Psitem" -Skip:$skip {
+                    $false	|  Should -BeTrue -Because "The instance should be available to be connected to!"
+                }
+            }
+        }
+        else {
+            Context "Testing if the login password expiratin is enabeld for sql logins in the sysadmin role on $psitem" {
+                It "All sql logins should have the password expiration option set to ON in the sysadmin role on $psitem" -Skip:$skip {
+                    Assert-LoginPasswordExpiration -AllInstanceInfo $AllInstanceInfo
+                }
+            }
+        }
+    }
 }
 
 Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, High, $filename {

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -1061,7 +1061,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
         else {
-            Context "Testing if the new SQL logins that have not logged have to change their password when they log in on $psitem" -Skip:$skip {
+            Context "Testing if the new SQL logins that have not logged have to change their password when they log in on $psitem" -Skip:$skip{
                 It "All new sql logins should have the have to change their password when they log in for the first time on $psitem" {
                     Assert-LoginMustChange -AllInstanceInfo $AllInstanceInfo
                 }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -1026,7 +1026,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
         else {
             Context "Testing if the CHECK_POLICY is enabled on all logins on $psitem" {
-                It "All logins should have the CHECK_POLICY option set to ON on $psitem" {
+                It "All logins should have the CHECK_POLICY option set to ON on $psitem" -Skip:$skip {
                     Assert-LoginCheckPolicy -AllInstanceInfo $AllInstanceInfo
                 }
             }

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -570,7 +570,7 @@ function Get-AllInstanceInfo {
             if ($There) {
                 try {
                     $LoginMustChange = [pscustomobject] @{
-                        Count = @(Get-DbaLogin -SQLInstance . -Type SQL | Where-Object { $_.MustChangePassword -eq $false -and $_.IsDisabled -eq $false -and $_.LastLogin -eq $null }).Count
+                        Count = @(Get-DbaLogin -SQLInstance . -Type SQL | Where-Object { $_.MustChangePassword -eq $false -and $_.IsDisabled -eq $false -and $null -eq $_.LastLogin }).Count
                     }
                 }
                 catch {

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -500,7 +500,7 @@ function Get-AllInstanceInfo {
             if ($There) {
                 try {
                     $LoginCheckPolicy = [pscustomobject] @{
-                        Count = @(Get-DbaLogin -SQLInstance $instance -ExcludeSystemLogin| Where-Object { $_.PasswordPolicyEnforced -eq "OFF" -and $_.LoginType -eq "SqlLogin" }).Count
+                        Count = @(Get-DbaLogin -SQLInstance $instance -ExcludeSystemLogin| Where-Object { $_.PasswordPolicyEnforced -eq "OFF" -and $_.LoginType -eq "SqlLogin" -and $_.IsDisabled -eq $false}).Count
                     }
                 }
                 catch {

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -540,8 +540,7 @@ function Get-AllInstanceInfo {
                     Count = 'We Could not Connect to $Instance'
                 }
             }
-        }
-        
+        }        
         'LoginPasswordExpiration' {
             if ($There) {
                 try {
@@ -565,7 +564,6 @@ function Get-AllInstanceInfo {
                 }
             }
         }
-        
         'LoginMustChange' {
             if ($There) {
                 try {

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -540,7 +540,7 @@ function Get-AllInstanceInfo {
                     Count = 'We Could not Connect to $Instance'
                 }
             }
-        }        
+        }
         'LoginPasswordExpiration' {
             if ($There) {
                 try {
@@ -734,7 +734,7 @@ function Assert-TraceFlag {
 function Assert-NotTraceFlag {
     Param(
         [string]$SQLInstance,
-        [int[]]$NotExpectedTraceFlagA
+        [int[]]$NotExpectedTraceFlag
     )
 
     if ($null -eq $NotExpectedTraceFlag) {

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -478,5 +478,9 @@
     {
         "UniqueTag": "LoginCheckPolicy",
         "Description": "Tests to see if CHECK_POLICY property is set for all logins."
+    },
+    {
+        "UniqueTag": "LoginPasswordExpiration",
+        "Description": "Tests to see if password expiration policy is set for sql logins in sysadmin role."
     }
  ]

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -482,5 +482,9 @@
     {
         "UniqueTag": "LoginPasswordExpiration",
         "Description": "Tests to see if password expiration policy is set for sql logins in sysadmin role."
+    },
+    {
+        "UniqueTag": "LoginMustChange",
+        "Description": "Tests to see if password must change is enabled for new logins."
     }
  ]

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -474,5 +474,9 @@
     {
         "UniqueTag": "BuiltInAdmin",
         "Description": "Tests to see if the BUILTIN\\Administrator login exist."
+    },
+    {
+        "UniqueTag": "LoginCheckPolicy",
+        "Description": "Tests to see if CHECK_POLICY property is set for all logins."
     }
  ]

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -237,7 +237,7 @@ Set-PSFConfig -Module dbachecks -Name skip.instance.remoteaccessdisabled -Valida
 Set-PSFConfig -Module dbachecks -Name skip.instance.scanforstartupproceduresdisabled -Validation bool -Value $false -Initialize -Description "Skip the scan for startup procedures disabled check"
 Set-PSFConfig -Module dbachecks -Name skip.instance.latestbuild -Validation bool -Value $false -Initialize -Description "Skip the scan the latest build of SQL Server check"
 Set-PSFConfig -Module dbachecks -Name skip.security.sadisabled -Validation bool -Value $true -Initialize -Description "Skip the check for if the sa login is disabled"
-Set-PSFConfig -Module dbachecks -Name skip.security.saexist -Validation bool -Value $true -Initialize -Description "Skip the check for a login named sa does not exist"
+Set-PSFConfig -Module dbachecks -Name skip.security.saexist -Validation bool -Value -Initialize -Description "Skip the check for a login named sa does not exist"
 Set-PSFConfig -Module dbachecks -Name skip.security.containedbautoclose -Validation bool -Value $true -Initialize -Description "Skips the scan for contained databases should have auto close enabled"
 Set-PSFConfig -Module dbachecks -Name skip.security.loginauditlevelfailed -Validation bool -Value $true -Initialize -Description "Skips the scan for if server login level records failed logins"
 Set-PSFConfig -Module dbachecks -Name skip.security.loginauditlevelsuccessful -Validation bool -Value $true -Initialize -Description "Skips the scan for if server login level records successful and failed logins"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -245,6 +245,8 @@ Set-PSFConfig -Module dbachecks -Name skip.security.localwindowsgroup -Validatio
 Set-PSFConfig -Module dbachecks -Name skip.security.publicrolepermission -Validation bool -Value $true -Initialize -Description "Skips the scan for if the public server role has permissions"
 Set-PSFConfig -Module dbachecks -Name skip.security.builtinadmin -Validation bool -Value $true -Initialize -Description "Skips the scan for BUILTIN\Administrators login"
 Set-PSFConfig -Module dbachecks -Name skip.security.guestuserconnect -Validation bool -Value $true -Initialize -Description "Skips the scan for guest user have CONNECT permission"
+Set-PSFConfig -Module dbachecks -Name skip.security.LoginCheckPolicy -Validation bool -Value $true -Initialize -Description "Skips the scan for CHECK_POLICY on for all logins"
+
 #agent
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatorname -Value $null -Initialize -Description "Name of the DBA Operator in SQL Agent"
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatoremail -Value $null -Initialize -Description "Email address of the DBA Operator in SQL Agent"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -247,7 +247,7 @@ Set-PSFConfig -Module dbachecks -Name skip.security.builtinadmin -Validation boo
 Set-PSFConfig -Module dbachecks -Name skip.security.guestuserconnect -Validation bool -Value $true -Initialize -Description "Skips the scan for guest user have CONNECT permission"
 Set-PSFConfig -Module dbachecks -Name skip.security.LoginCheckPolicy -Validation bool -Value $true -Initialize -Description "Skips the scan for CHECK_POLICY on for all logins"
 Set-PSFConfig -Module dbachecks -Name skip.security.LoginPasswordExpiration -Validation bool -Value $true -Initialize -Description "Skips the scan for password expiration on for all logins in sysadmin role"
-
+Set-PSFConfig -Module dbachecks -Name skip.security.LoginMustChange -Validation bool -Value $true -Initialize -Description "Skips the scan for new logins must have password change turned on"
 #agent
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatorname -Value $null -Initialize -Description "Name of the DBA Operator in SQL Agent"
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatoremail -Value $null -Initialize -Description "Email address of the DBA Operator in SQL Agent"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -246,6 +246,7 @@ Set-PSFConfig -Module dbachecks -Name skip.security.publicrolepermission -Valida
 Set-PSFConfig -Module dbachecks -Name skip.security.builtinadmin -Validation bool -Value $true -Initialize -Description "Skips the scan for BUILTIN\Administrators login"
 Set-PSFConfig -Module dbachecks -Name skip.security.guestuserconnect -Validation bool -Value $true -Initialize -Description "Skips the scan for guest user have CONNECT permission"
 Set-PSFConfig -Module dbachecks -Name skip.security.LoginCheckPolicy -Validation bool -Value $true -Initialize -Description "Skips the scan for CHECK_POLICY on for all logins"
+Set-PSFConfig -Module dbachecks -Name skip.security.LoginPasswordExpiration -Validation bool -Value $true -Initialize -Description "Skips the scan for password expiration on for all logins in sysadmin role"
 
 #agent
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatorname -Value $null -Initialize -Description "Name of the DBA Operator in SQL Agent"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -237,7 +237,7 @@ Set-PSFConfig -Module dbachecks -Name skip.instance.remoteaccessdisabled -Valida
 Set-PSFConfig -Module dbachecks -Name skip.instance.scanforstartupproceduresdisabled -Validation bool -Value $false -Initialize -Description "Skip the scan for startup procedures disabled check"
 Set-PSFConfig -Module dbachecks -Name skip.instance.latestbuild -Validation bool -Value $false -Initialize -Description "Skip the scan the latest build of SQL Server check"
 Set-PSFConfig -Module dbachecks -Name skip.security.sadisabled -Validation bool -Value $true -Initialize -Description "Skip the check for if the sa login is disabled"
-Set-PSFConfig -Module dbachecks -Name skip.security.saexist -Validation bool -Value -Initialize -Description "Skip the check for a login named sa does not exist"
+Set-PSFConfig -Module dbachecks -Name skip.security.saexist -Validation bool -Value $true -Initialize -Description "Skip the check for a login named sa does not exist"
 Set-PSFConfig -Module dbachecks -Name skip.security.containedbautoclose -Validation bool -Value $true -Initialize -Description "Skips the scan for contained databases should have auto close enabled"
 Set-PSFConfig -Module dbachecks -Name skip.security.loginauditlevelfailed -Validation bool -Value $true -Initialize -Description "Skips the scan for if server login level records failed logins"
 Set-PSFConfig -Module dbachecks -Name skip.security.loginauditlevelsuccessful -Validation bool -Value $true -Initialize -Description "Skips the scan for if server login level records successful and failed logins"

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -1102,7 +1102,7 @@ InModuleScope dbachecks {
                         Exist = $true
                         }
                     }}
-                {Assert-SaExist -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected `$false, because We expected no login to exist with the name sa, but got `$true."
+                {Assert-SaExist -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0, because We expected no login to exist with the name sa, but got 1."
             }
         }
     }

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -1088,7 +1088,7 @@ InModuleScope dbachecks {
                 # Mock for success
                 Mock Get-AllInstanceInfo {[PSCustomObject]@{
                     SaExist = [PSCustomObject]@{
-                        Exist = $false
+                        Exist = 0
                     }
                 }
             }
@@ -1099,7 +1099,7 @@ InModuleScope dbachecks {
                 # Mock for failing test
                 Mock Get-AllInstanceInfo {[PSCustomObject]@{
                     SaExist = [PSCustomObject]@{
-                        Exist = $true
+                        Exist = 1
                         }
                     }}
                 {Assert-SaExist -AllInstanceInfo (Get-AllInstanceInfo)} | Should -Throw -ExpectedMessage "Expected 0, because We expected no login to exist with the name sa, but got 1."

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -2,6 +2,12 @@
 	"folders": [
 		{
 			"path": "."
+		},
+		{
+			"path": "C:\\Github\\dbadisa"
+		},
+		{
+			"path": "C:\\Github\\dbatools"
 		}
 	],
 	"settings": {


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

- CIS Check Ensure 'CHECK_POLICY' Option is set to 'ON' for All SQL Authenticated Logins
- CIS CHeck Ensure 'CHECK_EXPIRATION' Option is set to 'ON' for All SQL Authenticated Logins Within the Sysadmin Role
- CIS Check Ensure 'MUST_CHANGE' Option is set to 'ON' for All SQL Authenticated Logins for new logins
- Cleaned up two tests two user @().count instead of if for $nulls, much cleaner, BuiltIn Admin and SAExist 

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)