### PR TITLE
Do math on run_duration to get actual duration

### DIFF
--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -347,7 +347,7 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
                         SELECT
                         j.job_id,
                         j.name AS JobName,
-                        jh.run_duration AS Duration
+                        DATEDIFF(SECOND, 0, STUFF(STUFF(RIGHT('000000' + CONVERT(VARCHAR(6),jh.run_duration),6),5,0,':'),3,0,':')) AS Duration
                         FROM msdb.dbo.sysjobs j
                         INNER JOIN
                             (


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

- Fix calculation for duration on job run time.

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)