### PR TITLE
Wrong variable used in -SqlInstance

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,9 @@
+## Date 29th March 2020
+Thank you @dstrait
+    Fix variable for SaDisabled check #750
+
+##Latest
+
 ## Date 18th March 2020
 Thank you Tracey tboggiano
     New CIS user-defined CLRs to be set to SAFE_ACCESS #734
@@ -12,8 +18,6 @@ Thank you Rob
 Thank you mikedavem
     Fixed bug in disk allocation check exclusions
     Added multiple ags to the HADR check #742
-
-##Latest
 
 ## Date 14th March 2020
 Thank you Tracey tboggiano

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -297,7 +297,7 @@ function Get-AllInstanceInfo {
             if ($There) {
                 try {
                     #This needs to be done in query just in case the account had already been renamed
-                    $login = Get-DbaLogin -SqlInstance $server | Where-Object Id -eq 1
+                    $login = Get-DbaLogin -SqlInstance $Instance | Where-Object Id -eq 1
                     $SaDisabled = [pscustomobject] @{
                         Disabled = $login.IsDisabled
                     }


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)

I noticed a few things failing after updating the module on my admin workstation a while ago, but I didn't have time to debug this until today.

This is a simple case of using the wrong variable ($server) and not the variable that is used in all the other calls to dbatools cmdlets ($Instance). Another tell is that variable $server is not used anywhere else in Instance.Assertions.ps1

This one change takes my test environment from 11 failures to 7. 

/cheers