### PR TITLE
Fix ping computer syntax issues

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,8 @@
 Thank you @dstrait
     Fix variable for SaDisabled check #750
     Fix errant braces in SQL Browser Service Check #751
-
+    Fix PingComputer Check #752
+    
 Thank you Rob
     Some spellings!
 

--- a/internal/assertions/Server.Assertions.ps1
+++ b/internal/assertions/Server.Assertions.ps1
@@ -206,7 +206,7 @@ function Assert-Ping {
     $pingmsmax = Get-DbcConfigValue policy.connection.pingmaxms
     switch ($type) {
         Ping {
-            $AllServerInfo.PingComputer.Count | Should -Be $pingcount -Because "We expect the server to respond to ping"
+            ($AllServerInfo.PingComputer).Count | Should -Be $pingcount -Because "We expect the server to respond to ping"
         }
         Average {
             ($AllServerInfo.PingComputer | Measure-Object -Property ResponseTime -Average).Average / $pingcount | Should -BeLessThan $pingmsmax -Because "We expect the server to respond within $pingmsmax"

--- a/internal/assertions/Server.Assertions.ps1
+++ b/internal/assertions/Server.Assertions.ps1
@@ -209,7 +209,7 @@ function Assert-Ping {
             ($AllServerInfo.PingComputer).Count | Should -Be $pingcount -Because "We expect the server to respond to ping"
         }
         Average {
-            ($AllServerInfo.PingComputer | Measure-Object -Property ResponseTime -Average).Average / $pingcount | Should -BeLessThan $pingmsmax -Because "We expect the server to respond within $pingmsmax"
+            ($AllServerInfo.PingComputer | Measure-Object -Property Latency -Average).Average / $pingcount | Should -BeLessThan $pingmsmax -Because "We expect the server to respond within $pingmsmax"
         }
         Default {}
     }


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings
Found two issues with Ping Computer. 

First, "Ping" needed a little syntax so it actually found the Count of responses. This caused the test to think that there were zero responses when in fact there were more than zero.

Second, "Average" was using a Property of "ResponseTime", which is not an attribute returned by Test-Connection. This caused a hard failure because that property does not exist.The correct attribute seems to be Latency. 

/cheers