### PR TITLE
Pin Pester version

### DIFF
--- a/dbachecks.psd1
+++ b/dbachecks.psd1
@@ -51,7 +51,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules        = @(
-        @{ ModuleName = 'Pester'; ModuleVersion = '4.7.1' },
+        @{ ModuleName = 'Pester'; MaximumVersion = '4.99.99' },
         @{ ModuleName = 'dbatools'; ModuleVersion = '1.0.23' }
         @{ ModuleName = 'PSFramework'; ModuleVersion = '1.0.0' }
     )


### PR DESCRIPTION
[x] There are 0 failing Pester tests

## Changes this PR brings
Specify the maximum version of Pester to prevent breaking the module when Pester5 is released.