### PR TITLE
New Check - suspect_pages row limit nearing

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -1164,6 +1164,25 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
     }
+
+    Describe "Suspect Page Limit Nearing" -Tags SuspectPageLimit, Medium, $filename {
+        $skip = Get-DbcConfigValue skip.instance.suspectpagelimit
+        $thresholdPercent = Get-DbcConfigValue policy.suspectpages.threshold
+        if ($NotContactable -contains $psitem) {
+            Context "Testing if the suspect_pages table is nearing the limit of 1000 rows on $psitem" {
+                It "Can't Connect to $Psitem" -Skip:$skip {
+                    $false	| Should -BeTrue -Because "The instance should be available to be connected to!"
+                }
+            }
+        }
+        else {
+            Context "Testing if the suspect_pages table is nearing the limit of 1000 rows on $psitem" {
+                It "The suspect_pages table in msdb shouldn't be nearing the limit of 1000 rows on $psitem" -Skip:$skip {
+                    (((Get-DbaSuspectPage -SqlInstance $psitem | Measure-Object).Count)/1000)*100 | Should -BeLessThan $thresholdPercent
+                }
+            }
+        }
+    }
 }
 
 Describe "SQL Browser Service" -Tags SqlBrowserServiceAccount, ServiceAccount, High, $filename {

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -36,6 +36,10 @@
         "Description": "Tests that there are 0 Suspect Pages for the database"
     },
     {
+        "UniqueTag": "SuspectPageLimit",
+        "Description": "Tests that the suspect_pages table in msdb is not nearing the limit of 1000 rows"
+    },
+    {
         "UniqueTag": "TestLastBackup",
         "Description": "Restores the last backup of a database onto a specified (default blank so will use the same instance) restore instance and checks if the DBCC result was successful as well as the DBCC result. This can obviously take some time for large databases!"
     },

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -243,7 +243,7 @@ Set-PSFConfig -Module dbachecks -Name skip.instance.oleautomationproceduresdisab
 Set-PSFConfig -Module dbachecks -Name skip.instance.remoteaccessdisabled -Validation bool -Value $false -Initialize -Description "Skip the remote access check"
 Set-PSFConfig -Module dbachecks -Name skip.instance.scanforstartupproceduresdisabled -Validation bool -Value $false -Initialize -Description "Skip the scan for startup procedures disabled check"
 Set-PSFConfig -Module dbachecks -Name skip.instance.latestbuild -Validation bool -Value $false -Initialize -Description "Skip the scan the latest build of SQL Server check"
-Set-PSFConfig -Module dbachecks -Name skip.instance.suspectpagelimit -Validation bool -Value $false -Initialize -Description "Skip the check for whether the suspect_pages table is nearing the row limit"
+Set-PSFConfig -Module dbachecks -Name skip.instance.suspectpagelimit -Validation bool -Value $false -Initialize -Description "Skip the check for whether the suspect_pages table is nearing the row limit of 1000"
 Set-PSFConfig -Module dbachecks -Name skip.security.sadisabled -Validation bool -Value $true -Initialize -Description "Skip the check for if the sa login is disabled"
 Set-PSFConfig -Module dbachecks -Name skip.security.saexist -Validation bool -Value $true -Initialize -Description "Skip the check for a login named sa does not exist"
 Set-PSFConfig -Module dbachecks -Name skip.security.containedbautoclose -Validation bool -Value $true -Initialize -Description "Skips the scan for contained databases should have auto close enabled"
@@ -304,7 +304,7 @@ Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludedatabases -V
 Set-PSFConfig -Module dbachecks -Name testing.integration.instance -Value @("localhost") -Initialize -Description "Default SQL Server instances to be used by integration tests"
 
 # Suspect pages
-Set-PSFConfig -Module dbachecks -Name policy.suspectpages.threshold -Value 90 -Initialize -Description "Default threshold (%) to check whether suspect_pages is nearing row limit"
+Set-PSFConfig -Module dbachecks -Name policy.suspectpages.threshold -Value 90 -Initialize -Description "Default threshold (%) to check whether suspect_pages is nearing row limit of 1000"
 
 # Server
 Set-PSFConfig -Module dbachecks -Name policy.server.cpuprioritisation -Value $true -Initialize -Description "Shall we skip the CPU Prioritisation check"

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -243,6 +243,7 @@ Set-PSFConfig -Module dbachecks -Name skip.instance.oleautomationproceduresdisab
 Set-PSFConfig -Module dbachecks -Name skip.instance.remoteaccessdisabled -Validation bool -Value $false -Initialize -Description "Skip the remote access check"
 Set-PSFConfig -Module dbachecks -Name skip.instance.scanforstartupproceduresdisabled -Validation bool -Value $false -Initialize -Description "Skip the scan for startup procedures disabled check"
 Set-PSFConfig -Module dbachecks -Name skip.instance.latestbuild -Validation bool -Value $false -Initialize -Description "Skip the scan the latest build of SQL Server check"
+Set-PSFConfig -Module dbachecks -Name skip.instance.suspectpagelimit -Validation bool -Value $false -Initialize -Description "Skip the check for whether the suspect_pages table is nearing the row limit"
 Set-PSFConfig -Module dbachecks -Name skip.security.sadisabled -Validation bool -Value $true -Initialize -Description "Skip the check for if the sa login is disabled"
 Set-PSFConfig -Module dbachecks -Name skip.security.saexist -Validation bool -Value $true -Initialize -Description "Skip the check for a login named sa does not exist"
 Set-PSFConfig -Module dbachecks -Name skip.security.containedbautoclose -Validation bool -Value $true -Initialize -Description "Skips the scan for contained databases should have auto close enabled"
@@ -301,6 +302,9 @@ Set-PSFConfig -Module dbachecks -Name command.invokedbccheck.excludedatabases -V
 
 # config for integration testing
 Set-PSFConfig -Module dbachecks -Name testing.integration.instance -Value @("localhost") -Initialize -Description "Default SQL Server instances to be used by integration tests"
+
+# Suspect pages
+Set-PSFConfig -Module dbachecks -Name policy.suspectpages.threshold -Value 90 -Initialize -Description "Default threshold (%) to check whether suspect_pages is nearing row limit"
 
 # Server
 Set-PSFConfig -Module dbachecks -Name policy.server.cpuprioritisation -Value $true -Initialize -Description "Shall we skip the CPU Prioritisation check"


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests
```
Tests completed in 37.36s
Tests Passed: 1575, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0 
```

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)
- Adds a check that closes #764 

Created two config values, one to enable the check to be skipped, another for the % threshold, set at 90% for now, limit is 1000 rows.

Tested by inserting 901 rows into mssql1 suspect pages table
![image](https://user-images.githubusercontent.com/981370/81471131-e3e28400-91e6-11ea-8967-89f66428ba12.png)
