### PR TITLE
Skip option for LastBackup on AG Secondaries 

### DIFF
--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -217,6 +217,7 @@ Set-PSFConfig -Module dbachecks -Name policy.build.behind -Value $null -Initiali
 Set-PSFConfig -Module dbachecks -Name skip.dbcc.datapuritycheck -Validation bool -Value $false -Initialize -Description "Skip data purity check in last good dbcc command"
 Set-PSFConfig -Module dbachecks -Name skip.backup.testing -Validation bool -Value $true -Initialize -Description "Don't run Test-DbaLastBackup by default (it's not read-only)"
 Set-PSFConfig -Module dbachecks -Name skip.backup.readonly -Validation bool -Value $false -Initialize -Description "Check read-only databases for last backup"
+Set-PSFConfig -Module dbachecks -Name skip.backup.secondaries -Validation bool -Value $false -Initialize -Description "Check hadr secondary databases for last backup"
 Set-PSFConfig -Module dbachecks -Name skip.tempdb1118 -Validation bool -Value $false -Initialize -Description "Don't run test for Trace Flag 1118"
 Set-PSFConfig -Module dbachecks -Name skip.tempdbfilecount -Validation bool -Value $false -Initialize -Description "Don't run test for Temp Database File Count"
 Set-PSFConfig -Module dbachecks -Name skip.tempdbfilegrowthpercent -Validation bool -Value $false -Initialize -Description "Don't run test for Temp Database File Growth in Percent"


### PR DESCRIPTION
[X] There are 0 failing Pester tests

## Changes this PR brings
- adds a config option called `skip.backup.secondaries` defaults to false
- when config is set to true the three LastBackup checks will skip any databases that are in an AG and on a secondary replica

Set up test AG with localhost, 15592 as the primary... backups are all checked on that node, but databases in the AG are skipped on the secondary node.
```
Set-DbcConfig -Name skip.backup.secondaries -Value $true
Invoke-DbcCheck -SqlInstance $sql1, $sql2 -Check LastBackup
```
![image](https://user-images.githubusercontent.com/981370/86374784-dbee1000-bc7c-11ea-896f-65e05f75d2ef.png)
