### PR TITLE
Query Store enabled and disabled test

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -1094,10 +1094,14 @@ $ExcludedDatabases += $ExcludeDatabase
 
     Describe "Query Store Enabled" -Tags QueryStoreEnabled, Medium, $filename {
         $QSExcludedDatabases = Get-DbcConfigValue database.querystoreenabled.excludedb
-        $exclude = "master", "tempdb" , "msdb"
+        $exclude = "master", "tempdb" , "model"
         $ExcludedDatabases += $exclude
         $QSExcludedDatabases += $ExcludedDatabases
-        $Skip = ($InstanceSMO.Version.Major -ge 13 )
+        $Skip = Get-DbcConfigValue skip.security.querystoreenabled
+        if (!$skip -and $InstanceSMO.Version.Major -lt 13) {
+            $Skip = $true
+        }
+
         if ($NotContactable -contains $psitem) {
             Context "Testing to see if Query Store is enabled on $psitem" {
                 It "Can't Connect to $Psitem" -Skip:$skip {
@@ -1109,7 +1113,7 @@ $ExcludedDatabases += $ExcludeDatabase
             $instance = $Psitem
             Context "Testing to see if Query Store is enabled on $psitem" {
                 @($InstanceSMO.Databases.Where{ $(if ($Database) { $PsItem.Name -in $Database }else { $QSExcludedDatabases -notcontains $PsItem.Name }) }).Foreach{
-                    It "Database $($psitem.Name) should have Query Store enabled on $Instance" -Skip:($version -lt 13 ) {
+                    It "Database $($psitem.Name) should have Query Store enabled on $Instance" -Skip:$skip {
                         Assert-QueryStoreEnabled -Instance $InstanceSMO -Database $($psitem.Name)
                     }
                 }
@@ -1118,10 +1122,14 @@ $ExcludedDatabases += $ExcludeDatabase
     }
     Describe "Query Store Disabled" -Tags QueryStoreDisabled, Medium, $filename {
         $QSExcludedDatabases = Get-DbcConfigValue database.querystoredisabled.excludedb
-        $exclude = "master", "tempdb" , "msdb"
+        $exclude = "master", "tempdb" , "model"
         $ExcludedDatabases += $exclude
         $QSExcludedDatabases += $ExcludedDatabases
-        $Skip = ($InstanceSMO.Version.Major -ge 13 )
+        $Skip = Get-DbcConfigValue skip.security.querystoredisabled
+        if (!$skip -and $InstanceSMO.Version.Major -lt 13) {
+            $Skip = $true
+        }
+
         if ($NotContactable -contains $psitem) {
             Context "Testing to see if Query Store is disabled on $psitem" {
                 It "Can't Connect to $Psitem" -Skip:$skip {
@@ -1133,7 +1141,7 @@ $ExcludedDatabases += $ExcludeDatabase
             $instance = $Psitem
             Context "Testing to see if Query Store is disabled on $psitem" {
                 @($InstanceSMO.Databases.Where{ $(if ($Database) { $PsItem.Name -in $Database }else { $QSExcludedDatabases -notcontains $PsItem.Name }) }).Foreach{
-                    It "Database $($psitem.Name) should have Query Store disabled on $Instance" -Skip:($version -lt 13 ) {
+                    It "Database $($psitem.Name) should have Query Store disabled on $Instance" -Skip:$skip {
                         Assert-QueryStoreDisabled -Instance $InstanceSMO -Database $($psitem.Name)
                     }
                 }

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -254,6 +254,8 @@ Set-PSFConfig -Module dbachecks -Name skip.security.clrassembliessafe -Validatio
 Set-PSFConfig -Module dbachecks -Name skip.security.engineserviceadmin -Validation bool -Value $true -Initialize -Description "Skips the scan for the SQL Server Engine account is a local administrator"
 Set-PSFConfig -Module dbachecks -Name skip.security.agentserviceadmin -Validation bool -Value $true -Initialize -Description "Skips the scan for the SQL Server Agent account is a local administrator"
 Set-PSFConfig -Module dbachecks -Name skip.security.fulltextserviceadmin -Validation bool -Value $true -Initialize -Description "Skips the scan for the SQL Server Full Text account is a local administrator"
+Set-PSFConfig -Module dbachecks -Name skip.security.querystoredisabled -Validation bool -Value $true -Initialize -Description "Skips the check for if Query Store is disabled"
+Set-PSFConfig -Module dbachecks -Name skip.security.querystoreenabled -Validation bool -Value $false -Initialize -Description "Skips the check for if Query Store is enabled"
 Set-PSFConfig -Module dbachecks -Name skip.security.loginauditlevelfailed -Validation bool -Value $true -Initialize -Description "Skips the scan for if server login level records failed logins"
 Set-PSFConfig -Module dbachecks -Name skip.security.loginauditlevelsuccessful -Validation bool -Value $true -Initialize -Description "Skips the scan for if server login level records successful and failed logins"
 Set-PSFConfig -Module dbachecks -Name skip.security.localwindowsgroup -Validation bool -Value $true -Initialize -Description "Skips the scan for if local windows groups have SQL Logins"


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

- model database can't have Query store enabled but msdb can so switch that out
- test for if version is -lt 2016 rather than -ge version 13 to know if to skip
- since we have two test one for disabled and one for enabled, added skip options for both default enabled to not be skipped

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)
![image](https://user-images.githubusercontent.com/26776763/91080180-26ec2a00-e613-11ea-8289-afb5fb8b7a03.png)
