### PR TITLE
Fix for IsClustered checks for service startup types

### DIFF
--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -17,7 +17,7 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
             if ($null -eq $InstanceSMO.version) {
                 $NotContactable += $Instance
             }
-            elseif (($connectioncheck).Edition -like "Express Edition*") { }
+            elseif (($InstanceSMO).Edition -like "Express Edition*") { }
             else {
                 Describe "Database Mail XPs" -Tags DatabaseMailEnabled, CIS, security, $filename {
                     $DatabaseMailEnabled = Get-DbcConfigValue policy.security.DatabaseMailEnabled
@@ -54,7 +54,7 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
                                     It "SQL Agent should be running for $($psitem.InstanceName) on $($psitem.ComputerName)" {
                                         $psitem.State | Should -Be "Running" -Because 'The agent service is required to run SQL Agent jobs'
                                     }
-                                    if ($connectioncheck.IsClustered) {
+                                    if ($InstanceSMO.IsClustered) {
                                         It "SQL Agent service should have a start mode of Manual for FailOver Clustered Instance $($psitem.InstanceName) on $($psitem.ComputerName)" {
                                             $psitem.StartMode | Should -Be "Manual" -Because 'Clustered Instances required that the Agent service is set to manual'
                                         }

--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -98,7 +98,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
             }
         }
         else {
-            $IsClustered = $Psitem.IsClustered
+            $IsClustered = $InstanceSMO.IsClustered
             Context "Testing SQL Engine Service on $psitem" {
                 if ( -not $IsLInux) {
                     @(Get-DbaService -ComputerName $psitem -Type Engine -ErrorAction SilentlyContinue).ForEach{


### PR DESCRIPTION
Seems IsClustered was looking at the wrong params, changed to the $InstanceSMO and now drops into the right pieces for a FCI

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)