### PR TITLE
CertCheck took ages to run, was still checking excluded DB's then filtering, change to not query the excluded DBs

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -697,7 +697,7 @@ $ExcludedDatabases += $ExcludeDatabase
         }
         else {
             Context "Checking that encryption certificates have not expired on $psitem" {
-                @(Get-DbaDbEncryption -SqlInstance $psitem -IncludeSystemDBs -Database $Database | Where-Object { $_.Encryption -eq "Certificate" -and ($_.Database -notin $exclude) }).ForEach{
+                @(Get-DbaDbEncryption -SqlInstance $psitem -IncludeSystemDBs -Database $Database -ExcludeDatabase $exclude | Where-Object { $_.Encryption -eq "Certificate" -and ($_.Database -notin $exclude) }).ForEach{
                     It "Database $($psitem.Database) certificate $($psitem.Name) has not expired on $($psitem.SqlInstance)" {
                         $psitem.ExpirationDate.ToUniversalTime() | Should -BeGreaterThan (Get-Date).ToUniversalTime() -Because "this certificate should not be expired"
                     }
@@ -1051,7 +1051,7 @@ $ExcludedDatabases += $ExcludeDatabase
     }
     Describe "AsymmetricKeySize" -Tags AsymmetricKeySize, CIS, $filename {
         $skip = Get-DbcConfigValue skip.security.asymmetrickeysize
-        $ExcludedDatabases += "master", "tempdb", "msdb"
+        $ExcludedDatabases = $ExcludedDatabases + "master", "tempdb", "msdb"
         if ($NotContactable -contains $psitem) {
             Context "Testing Asymmetric Key Size is 2048 or higher on $psitem" {
                 It "Can't Connect to $Psitem" {
@@ -1072,7 +1072,7 @@ $ExcludedDatabases += $ExcludeDatabase
 
     Describe "SymmetricKeyEncryptionLevel" -Tags SymmetricKeyEncryptionLevel, CIS, $filename {
         $skip = Get-DbcConfigValue skip.security.symmetrickeyencryptionlevel
-        $ExcludedDatabases += "master", "tempdb", "msdb"
+        $ExcludedDatabases = $ExcludedDatabases + "master", "tempdb", "msdb"
         if ($NotContactable -contains $psitem) {
             Context "Testing Symmetric Key Encryption Level at least AES_128 or higher on $psitem" {
                 It "Can't Connect to $Psitem" -Skip:$skip {


### PR DESCRIPTION
CertCheck would still check the databases in the exclusion list, then filter them out at the end, this was very time consuming on a heavy used SSISDB, used the -ExcludeDatabase param on the Get-DbaDbEncryption to not even try and check certificates where the database is in the config for exclusion, so its quicker and left the original filter in as a safety net

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)