### PR TITLE
Add policy to exclude databases on the trustworthy check

### DIFF
--- a/checks/Database.Tests.ps1
+++ b/checks/Database.Tests.ps1
@@ -808,6 +808,8 @@ $ExcludedDatabases += $ExcludeDatabase
     }
 
     Describe "Trustworthy Option" -Tags Trustworthy, DISA, Varied, CIS, $filename {
+        $exclude = Get-DbcConfigValue policy.database.trustworthyexcludedb
+        $exclude += $ExcludedDatabases
         if ($NotContactable -contains $psitem) {
             Context "Testing database trustworthy option on $psitem" {
                 It "Can't Connect to $Psitem" {
@@ -817,7 +819,7 @@ $ExcludedDatabases += $ExcludeDatabase
         }
         else {
             Context "Testing database trustworthy option on $psitem" {
-                @($InstanceSMO.Databases.Where{ $psitem.Name -ne 'msdb' -and ($(if ($Database) { $PsItem.Name -in $Database }else { $ExcludedDatabases -notcontains $PsItem.Name })) }).ForEach{
+                @($InstanceSMO.Databases.Where{ $psitem.Name -ne 'msdb' -and ($(if ($Database) { $PsItem.Name -in $Database }else { $exclude -notcontains $PsItem.Name })) }).ForEach{
                     It "Database $($psitem.Name) should have Trustworthy set to false on $($psitem.Parent.Name)" {
                         $psitem.Trustworthy | Should -BeFalse -Because "Trustworthy has security implications and may expose your SQL Server to additional risk"
                     }

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -150,6 +150,7 @@ Set-PSFConfig -Module dbachecks -Name policy.database.status.excludeoffline -Val
 Set-PSFConfig -Module dbachecks -Name policy.database.status.excluderestoring -Value @() -Initialize -Description "Database names that we expect to be restoring"
 Set-PSFConfig -Module dbachecks -Name database.querystoreenabled.excludedb -Value @() -Initialize -Description "A List of databases that we do not want to check for Query Store enabled"
 Set-PSFConfig -Module dbachecks -Name database.querystoredisabled.excludedb -Value @() -Initialize -Description "A List of databases that we do not want to check for Query Store disabled"
+Set-PSFConfig -Module dbachecks -Name policy.database.trustworthyexcludedb -Value @() -Initialize -Description "A List of databases that we do not want to check for Trustworthy being on"
 
 # Policy for Ola Hallengren Maintenance Solution
 Set-PSFConfig -Module dbachecks -name policy.ola.installed -Validation bool -Value $true -Initialize -Description "Checks to see if Ola Hallengren solution is installed"


### PR DESCRIPTION
Recent implementation of Azure Information Protection scanning resulted in a new database being created which Microsoft need to have trustworthy set to on, this chucked out the error, so to not exclude the DB from all checks, added new policy to exclude it from this one check instead

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)