### PR TITLE
Date filter for memory dumps & Fix for anything 2008

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -359,7 +359,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
         else {
             Context "Checking that dumps on $psitem do not exceed $maxdumps for $psitem" {
-                It "dump count of $count is less than or equal to the $maxdumps dumps on $psitem" -Skip:($InstanceSMO.Version.Major -lt 10 ) {
+                It "dump count of $count is less than or equal to the $maxdumps dumps on $psitem" -Skip:($InstanceSMO.Version.Major -lt 11 -and (-not ($InstanceSMO.Version.Major -eq 10 -and $InstanceSMO.Version.Minor -eq 50)) ) {
                     Assert-MaxDump -AllInstanceInfo $AllInstanceInfo -maxdumps $maxdumps
                 }
             }

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -227,10 +227,17 @@ function Get-AllInstanceInfo {
         'MemoryDump' {
             if ($There) {
                 try {
+                    $daystocheck = Get-DbcConfigValue policy.instance.memorydumpsdaystocheck
+                    if ($null -eq $daystocheck) {
+                        $datetocheckfrom = '0001-01-01'
+                    }
+                    else {
+                        $datetocheckfrom = (Get-Date).ToUniversalTime().AddDays( - $daystocheck )
+                    }
                     $MaxDump = [pscustomobject] @{
                         # Warning Action removes dbatools output for version too low from test results
                         # Skip on the it will show in the results
-                        Count = (Get-DbaDump -SqlInstance $Instance -WarningAction SilentlyContinue).Count
+                        Count = (@(Get-DbaDump -SqlInstance $Instance -WarningAction SilentlyContinue).Where{ $_.CreationTime -gt $datetocheckfrom}).Count
                     }
                 }
                 catch {

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -39,6 +39,7 @@ Set-PSFConfig -Module dbachecks -Name app.cluster -Value $null -Initialize -Desc
 #instance
 Set-PSFConfig -Module dbachecks -Name policy.instance.sqlenginestart -Value 'Automatic' -Initialize -Description "The expected start type of the SQL Engine Service - Automatic, Manual, Disabled - Defaults to Automatic"
 Set-PSFConfig -Module dbachecks -Name policy.instance.sqlenginestate -Value 'Running' -Initialize -Description "The expected state of the SQL Engine Service - Running, Stopped - Defaults to Running"
+Set-PSFConfig -Module dbachecks -Name policy.instance.memorydumpsdaystocheck -Value $null -Initialize -Description "The number of days to go back and check for memory dumps"
 
 #Storage
 Set-PSFConfig -Module dbachecks -Name policy.storage.backuppath -Value $null -Initialize -Description "Enables tests to check if servers have access to centralized backup location"


### PR DESCRIPTION
Added a date filter for memory dumps, some of the server I check had dumps going back years, don't want to see that far back.
New policy.instance.memorydumpsdaystocheck configuration option for people to set to enable this.

Also fixed the version check as -lt resulted in 2008 servers being passed in and not gracefully failing the test, checked the version the same as Find-DbaDump does, 2008 now skip correctly

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)