### PR TITLE
New Check - Agent Mail Profile

### DIFF
--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -135,7 +135,7 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
                         Context "Testing database mail profile is set on $psitem" {
                             $databasemailprofile = Get-DbcConfigValue  agent.databasemailprofile
                             It "The Database Mail profile $databasemailprofile exists on $psitem" {
-                                (Get-DbaDbMailProfile -SqlInstance $InstanceSMO).Name | Should -Be $databasemailprofile -Because 'The database mail profile is required to send emails'
+                                ((Get-DbaDbMailProfile -SqlInstance $InstanceSMO).Name -contains $databasemailprofile) | Should -Be $true -Because 'The database mail profile is required to send emails'
                             }
                         }
                     }

--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -141,6 +141,24 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
                     }
                 }
 
+                Describe "Agent Mail Profile" -Tags AgentMailProfile, $filename {
+                    if ($NotContactable -contains $psitem) {
+                        Context "Testing SQL Agent Alert System database mail profile is set on $psitem" {
+                            It "Can't Connect to $Psitem" {
+                                $false | Should -BeTrue -Because "The instance should be available to be connected to!"
+                            }
+                        }
+                    }
+                    else {
+                        Context "Testing SQL Agent Alert System database mail profile is set on $psitem" {
+                            $agentmailprofile = Get-DbcConfigValue  agent.databasemailprofile
+                            It "The SQL Server Agent Alert System should have an enabled database mail profile on $psitem" {
+                                (Get-DbaAgentServer -SqlInstance $InstanceSMO).DatabaseMailProfile | Should -Be $agentmailprofile -Because 'The SQL Agent Alert System needs an enabled database mail profile to send alert emails'
+                            }
+                        }
+                    }
+                }
+
                 Describe "Failed Jobs" -Tags FailedJob, $filename {
 
                     if ($NotContactable -contains $psitem) {

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -537,5 +537,9 @@
     {
         "UniqueTag": "NonStandardPort",
         "Description": "Tests to see if the SQL Server Instances are NOT running on the default port of 1433."
+    },
+    {
+        "UniqueTag": "AgentMailProfile",
+        "Description": "Tests to see if the SQL Server Agent Alert System has an enabled database mail profile."
     }
 ]

--- a/tests/Unit.Tests.ps1
+++ b/tests/Unit.Tests.ps1
@@ -160,7 +160,7 @@ Describe "Checking that each dbachecks Pester test is correctly formatted for Po
                             }
                         }
                         It "$CheckName should have the right number of Context blocks as the AST doesnt parse how I like and I cant be bothered to fix it right now"{
-                            $Contexts.Count | Should -Be 25 -Because "There should be 25 context blocks in the Agent checks file"
+                            $Contexts.Count | Should -Be 27 -Because "There should be 27 context blocks in the Agent checks file"
                         }
                     }
                 }


### PR DESCRIPTION
Checks where checking that Mail XPs and a Mail Profile existed but not the the SQL Agent had been configured to use said mail profile.

Use Get-DbaAgentServer to pull out the configured DatabaseMailProfile and check it against the required database mail profile.

Systems not enabled will output empty so will fail against $null or a configured value.

This check is needed as without it you cant send alerts from the agent so the checks for email enabled alerts on Sev16-25 etc need this to be on.

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)