### PR TITLE
Scan for startup procs, use config option to override the value in use

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -882,6 +882,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
 
     Describe "Scan For Startup Procedures" -Tags ScanForStartupProceduresDisabled, Security, CIS, Medium, $filename {
         $skip = Get-DbcConfigValue skip.instance.scanforstartupproceduresdisabled
+        $ScanForStartupProcsDisabled = Get-DbcConfigValue policy.security.scanforstartupproceduresdisabled
         if ($NotContactable -contains $psitem) {
             Context "Testing Scan For Startup Procedures on $psitem" {
                 It "Can't Connect to $Psitem" -Skip:$skip {
@@ -891,8 +892,8 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
         else {
             Context "Testing Scan For Startup Procedures on $psitem" {
-                It "Scan For Startup Procedures should be disabled on $psitem" -Skip:$skip {
-                    Assert-ScanForStartupProcedures -AllInstanceInfo $AllInstanceInfo
+                It "Scan For Startup Procedures is set to $ScanForStartupProcsDisabled on $psitem" -Skip:$skip {
+                    Assert-ScanForStartupProcedures -AllInstanceInfo $AllInstanceInfo -ScanForStartupProcsDisabled $ScanForStartupProcsDisabled
                 }
             }
         }

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -823,8 +823,8 @@ function Assert-OleAutomationProcedures {
 function Assert-ScanForStartupProcedures {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
     [CmdletBinding()]
-    param ($AllInstanceInfo)
-    $AllInstanceInfo.ScanForStartupProceduresDisabled.ConfiguredValue | Should -Be 0 -Because "We expected the scan for startup procedures to be disabled"
+    param ($AllInstanceInfo, $ScanForStartupProcsDisabled)
+    ($AllInstanceInfo.ScanForStartupProceduresDisabled.ConfiguredValue -eq 0)  | Should -Be $ScanForStartupProcsDisabled -Because "We expected the scan for startup procedures to be configured correctly"
 }
 function Assert-MaxDump {
     Param($AllInstanceInfo, $maxdumps)

--- a/tests/checks/InstanceChecks.Tests.ps1
+++ b/tests/checks/InstanceChecks.Tests.ps1
@@ -783,7 +783,7 @@ InModuleScope dbachecks {
         }
         Context "Checking Scan For Startup Procedures Entries" {
 
-            It "Should pass the test successfully when scan for startup procedures is disabled" {
+            It "Should pass the test successfully when scan for startup procedures is disabled and config is true" {
                 # Mock for success
                 Mock Get-AllInstanceInfo { [PSCustomObject]@{
                         ScanForStartupProceduresDisabled = [PSCustomObject]@{
@@ -791,17 +791,38 @@ InModuleScope dbachecks {
                         }
                     }
                 }
-                Assert-ScanForStartupProcedures -AllInstanceInfo (Get-AllInstanceInfo)
+                Assert-ScanForStartupProcedures -AllInstanceInfo (Get-AllInstanceInfo) -ScanForStartupProcsDisabled $true
             }
 
-            It "Should fail the test successfully when scan for startup procedures is enabled" {
+            It "Should fail the test successfully when scan for startup procedures is disabled and config is false" {
+                # Mock for failing test
+                Mock Get-AllInstanceInfo { [PSCustomObject]@{
+                        ScanForStartupProceduresDisabled = [PSCustomObject]@{
+                            ConfiguredValue = 0
+                        }
+                    } }
+                { Assert-ScanForStartupProcedures -AllInstanceInfo (Get-AllInstanceInfo) -ScanForStartupProcsDisabled $false } | Should -Throw -ExpectedMessage "Expected `$false, because We expected the scan for startup procedures to be configured correctly, but got `$true."
+            }
+
+            It "Should pass the test successfully when scan for startup procedures is enabled and config is false" {
+                # Mock for success
+                Mock Get-AllInstanceInfo { [PSCustomObject]@{
+                        ScanForStartupProceduresDisabled = [PSCustomObject]@{
+                            ConfiguredValue = 1
+                        }
+                    }
+                }
+                Assert-ScanForStartupProcedures -AllInstanceInfo (Get-AllInstanceInfo) -ScanForStartupProcsDisabled $false
+            }
+
+            It "Should fail the test successfully when scan for startup procedures is enabled and config is true" {
                 # Mock for failing test
                 Mock Get-AllInstanceInfo { [PSCustomObject]@{
                         ScanForStartupProceduresDisabled = [PSCustomObject]@{
                             ConfiguredValue = 1
                         }
                     } }
-                { Assert-ScanForStartupProcedures -AllInstanceInfo (Get-AllInstanceInfo) } | Should -Throw -ExpectedMessage "Expected 0, because We expected the scan for startup procedures to be disabled, but got 1."
+                { Assert-ScanForStartupProcedures -AllInstanceInfo (Get-AllInstanceInfo) -ScanForStartupProcsDisabled $true } | Should -Throw -ExpectedMessage "Expected `$true, because We expected the scan for startup procedures to be configured correctly, but got `$false."
             }
         }
         Context "Checking Cross DB Ownership Chaining" {


### PR DESCRIPTION
The configuration option wasn't being used for ScanForStartupProcsDisabled, things like Transactional Replication need scan for startup enabling, even though config was set check would still fail

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)