### PR TITLE
Fix issue #782

### DIFF
--- a/checks/Instance.Tests.ps1
+++ b/checks/Instance.Tests.ps1
@@ -704,6 +704,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
     }
 
     Describe "Error Log Entries" -Tags ErrorLog, Medium, $filename {
+        $logwindow = Get-DbcConfigValue policy.errorlog.warningwindow
         if ($NotContactable -contains $psitem) {
             Context "Checking error log on $psitem" {
                 It "Can't Connect to $Psitem" {
@@ -713,7 +714,7 @@ $Tags = Get-CheckInformation -Check $Check -Group Instance -AllChecks $AllChecks
         }
         else {
             Context "Checking error log on $psitem" {
-                It "Error log should be free of error severities 17-24 on $psitem" {
+                It "Error log should be free of error severities 17-24 within the window of $logwindow days on $psitem" {
                     Assert-ErrorLogEntry -AllInstanceInfo $AllInstanceInfo
                 }
             }


### PR DESCRIPTION
# A New PR

## Please confirm you have 0 failing Pester Tests

[x] There are 0 failing Pester tests

## Changes this PR brings

Fix issue #782 
Using Config value "policy.errorlog.warningwindow" in the "Error Log Entries" Test makes it appear in the Get-DbcCheck output.

![image](https://user-images.githubusercontent.com/35964428/98483073-ebbac980-2205-11eb-983e-fe2dc03cc13a.png)
