### PR TITLE
Add additional filter to filter out negative run_durations

### DIFF
--- a/checks/Agent.Tests.ps1
+++ b/checks/Agent.Tests.ps1
@@ -336,6 +336,7 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
         WHERE start_execution_date is not null
         AND stop_execution_date is null
         AND run_duration < 235959
+        AND run_duration >= 0
         AND ja.start_execution_date > DATEADD(day,-1,GETDATE())
         GROUP BY j.name,j.job_id,start_execution_date,stop_execution_date,ja.job_id
         ) AS t
@@ -405,6 +406,7 @@ Set-PSFConfig -Module dbachecks -Name global.notcontactable -Value $NotContactab
                         FROM msdb.dbo.sysjobhistory hist
                         WHERE msdb.dbo.agent_datetime(run_date, run_time) > DATEADD(DAY,- $maxdays,GETDATE())
                         AND Step_id = 0
+                        AND run_duration >= 0
                         GROUP BY job_id
                         ) as art
 


### PR DESCRIPTION
Some run_durations where being reported as negative numbers causing the checks to fail with conversion issues, added check for >= 0
Seemed to be some strange edge case on a couple of the servers for this issue.

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)