### PR TITLE
Update Instance.Assertions.ps1

### DIFF
--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -587,12 +587,12 @@ function Get-AllInstanceInfo {
                     }
                     catch [System.Exception] {
                         if ($_.Exception.Message -like '*No services found in relevant namespaces*') {
-                            $FullTextServiceAdmin = [pscustomobject] @{
+                            $EngineServiceAdmin = [pscustomobject] @{
                                 Exist = $false
                             }
                         }
                         else {
-                            $FullTextServiceAdmin = [pscustomobject] @{
+                            $EngineServiceAdmin = [pscustomobject] @{
                                 Exist = 'Some sort of failure'
                             }
                         }
@@ -635,12 +635,12 @@ function Get-AllInstanceInfo {
                     }
                     catch [System.Exception] {
                         if ($_.Exception.Message -like '*No services found in relevant namespaces*') {
-                            $FullTextServiceAdmin = [pscustomobject] @{
+                            $AgentServiceAdmin = [pscustomobject] @{
                                 Exist = $false
                             }
                         }
                         else {
-                            $FullTextServiceAdmin = [pscustomobject] @{
+                            $AgentServiceAdmin = [pscustomobject] @{
                                 Exist = 'Some sort of failure'
                             }
                         }


### PR DESCRIPTION
Updated the params for each serviceadmin check to use the right one so the right error message is given.

Needs a doc change as this required PowerShell 5.1 to be installed on the remote machine to use the get-localgroupmember function which on older operating systems is not installed by default
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)