### PR TITLE
Percent log used check

### DIFF
--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -120,6 +120,10 @@
         "Description": "Tests that the database log files are less than the specified percentage of the specified comparison (maximum size or average - default is average) of the data file size (default 100)"
     },
     {
+        "UniqueTag": "LogfilePercentUsed",
+        "Description": "Tests that the database percent log file used is less than the specified percentage (default 75)"
+    },
+    {
         "UniqueTag": "FutureFileGrowth",
         "Description": "Tests if a database (except for those specified to be skipped explicitly) has free space less than the specified percentage (default 20)"
     },

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -163,6 +163,7 @@ Set-PSFConfig -Module dbachecks -Name policy.database.filegrowthdaystocheck -Val
 Set-PSFConfig -Module dbachecks -Name policy.database.trustworthyexcludedb -Value @() -Initialize -Description "A List of databases that we do not want to check for Trustworthy being on"
 Set-PSFConfig -Module dbachecks -Name policy.database.duplicateindexexcludedb -Value @('msdb','ReportServer','ReportServerTempDB') -Initialize -Description "A List of databases we do not want to check for Duplicate Indexes"
 Set-PSFConfig -Module dbachecks -Name policy.database.clrassembliessafeexcludedb -Value @() -Initialize -Description " A List of database what we do not want to check for SAFE CLR Assemblies"
+Set-PSFConfig -Module dbachecks -Name policy.database.logfilepercentused -Value 75 -Initialize -Description " The % log used we should stay below"
 
 # Policy for Ola Hallengren Maintenance Solution
 Set-PSFConfig -Module dbachecks -name policy.ola.installed -Validation bool -Value $true -Initialize -Description "Checks to see if Ola Hallengren solution is installed"


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)

Add LogfilePercentUsed check. Log might fill even if simple recovery model or full recovery model + Tlog backup in case of replication, CDC, HADR issues.