### PR TITLE
HADR - Fix NetBios Over TCP/IP check variable typo

### DIFF
--- a/checks/HADR.Tests.ps1
+++ b/checks/HADR.Tests.ps1
@@ -217,7 +217,7 @@ foreach ($clustervm in $clusters) {
                                         -Filter "InterfaceIndex = $((Get-NetAdapter -CimSession $node.Name -Name $netinterface).ifIndex)"
 
                     It "NetBios Over TCP/IP should be disabled for cluster network interface - Node $($node.Name)" -Skip:$skipClusterNetInterface {
-                        $Adapter.TcpipNetbiosOptions | Should -Be 2 -Because "Heartbeat traffic doesn't use NetBios resolution"
+                        $AdapterNetBios.TcpipNetbiosOptions | Should -Be 2 -Because "Heartbeat traffic doesn't use NetBios resolution"
                     }
                 }
             }


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

All Tests ran successfully on my local machine

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

Fix previous PR issue - HADR Tests - Adding checks
Test NetBios Over TCP/IP should be disabled for cluster network interface 