### PR TITLE
Fix VERBOSE by default when importing module dbachecks

### DIFF
--- a/checks/HADR.Tests.ps1
+++ b/checks/HADR.Tests.ps1
@@ -217,7 +217,7 @@ foreach ($clustervm in $clusters) {
                                         -Filter "InterfaceIndex = $((Get-NetAdapter -CimSession $node.Name -Name $netinterface).ifIndex)"
 
                     It "NetBios Over TCP/IP should be disabled for cluster network interface - Node $($node.Name)" -Skip:$skipClusterNetInterface {
-                        $Adapter.TcpipNetbiosOptions | Should -Be 2 -Because "Heartbeat traffic doesn't use NetBios resolution"
+                        $AdapterNetBios.TcpipNetbiosOptions | Should -Be 2 -Because "Heartbeat traffic doesn't use NetBios resolution"
                     }
                 }
             }

--- a/dbachecks.psm1
+++ b/dbachecks.psm1
@@ -1,5 +1,5 @@
 ﻿$script:ModuleRoot = $PSScriptRoot
-$VerbosePreference = "Continue"
+$VerbosePreference = "SilentlyContinue"
 
 ## Rotten way to fix Pester v5 issues
 
@@ -9,7 +9,7 @@ if ((Get-Module Pester).Version.Major -eq 5) {
 
     try {
         Remove-Module Pester -Force
-        $CompatibleInstalledPester = Get-Module Pester -ListAvailable | Where { $Psitem.Version.Major -le 4 } | Sort Version -Descending | Select -First 1 
+        $CompatibleInstalledPester = Get-Module Pester -ListAvailable | Where { $Psitem.Version.Major -le 4 } | Sort Version -Descending | Select -First 1
         Write-PSFMessage -Message "Removed Version 5 trying to import version $($CompatibleInstalledPester.Version.ToString())"
         Import-Module $CompatibleInstalledPester.Path -Verbose -Scope Global
     }
@@ -20,7 +20,7 @@ if ((Get-Module Pester).Version.Major -eq 5) {
 }
 else {
     try {
-        $CompatibleInstalledPester = Get-Module Pester -ListAvailable | Where { $Psitem.Version.Major -le 4 } | Sort Version -Descending | Select -First 1 
+        $CompatibleInstalledPester = Get-Module Pester -ListAvailable | Where { $Psitem.Version.Major -le 4 } | Sort Version -Descending | Select -First 1
         Write-PSFMessage -Message "Trying to import version $($CompatibleInstalledPester.Version.ToString())"
         Import-Module $CompatibleInstalledPester.Path -Verbose -Scope Global
     }


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

All tests ran successfully on my local machine

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

Fix issue #826 