### PR TITLE
the tests to reflect changes in db assertions

### DIFF
--- a/tests/checks/DatabaseChecks.Tests.ps1
+++ b/tests/checks/DatabaseChecks.Tests.ps1
@@ -358,7 +358,7 @@ Describe "Checking Database.Assertions.ps1 assertions" -Tag UnitTest, Assertions
             }
         }
         It "Should fail for one duplicate index" {
-            {Assert-DatabaseDuplicateIndex -Instance Dummy -Database Dummy1 } | Should -Throw -ExpectedMessage 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory, but got 1.'
+            {Assert-DatabaseDuplicateIndex -Instance Dummy -Database Dummy1 } | Should -Throw -ExpectedMessage 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory - Use Find-DbaDbDuplicateIndex to find them, but got 1.'
         }
         #Mock for failing for 2 indexes
         Mock Find-DbaDbDuplicateIndex {
@@ -392,7 +392,7 @@ Describe "Checking Database.Assertions.ps1 assertions" -Tag UnitTest, Assertions
         }
 
         It "Should fail for more than one duplicate index" {
-            {Assert-DatabaseDuplicateIndex -Instance Dummy -Database Dummy1 } | Should -Throw -ExpectedMessage 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory, but got 2.'
+            {Assert-DatabaseDuplicateIndex -Instance Dummy -Database Dummy1 } | Should -Throw -ExpectedMessage 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory - Use Find-DbaDbDuplicateIndex to find them, but got 2.'
         }
     }
     Context "Testing Assert-DatabaseExists" {


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[x] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)

It's related to this commit:
https://github.com/sqlcollaborative/dbachecks/commit/38e3d774409c3d64fb5b3c1e604ed1c05f06ddd3#diff-fc48f8054390ae4e86ca460b687ae4c864b55f1a7f03d984a1c21f076e4d53ef

One of the [builds](https://github.com/sqlcollaborative/dbachecks/pull/838/checks?check_run_id=2291673808) failed with the errors as there was a piece of the message added to the Database.Assertions and not into the tests.

```
 Context Testing Assert-DatabaseDuplicateIndex
      [-] Should fail for one duplicate index 123ms
        Expected an exception, with message 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory, but got 1.' to be thrown, but the message was 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory - Use Find-DbaDbDuplicateIndex to find them, but got 1.'. from C:\Program Files\WindowsPowerShell\Modules\Pester\4.10.0\Functions\Assertions\Should.ps1:180 char:9
            +         throw ( New-ShouldErrorRecord -Message $testResult.FailureMes ...
            +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        361:             {Assert-DatabaseDuplicateIndex -Instance Dummy -Database Dummy1 } | Should -Throw -ExpectedMessage 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory, but got 1.'
        at <ScriptBlock>, D:\a\dbachecks\dbachecks\tests\checks\DatabaseChecks.Tests.ps1: line 361
      [-] Should fail for more than one duplicate index 24ms
        Expected an exception, with message 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory, but got 2.' to be thrown, but the message was 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory - Use Find-DbaDbDuplicateIndex to find them, but got 2.'. from C:\Program Files\WindowsPowerShell\Modules\Pester\4.10.0\Functions\Assertions\Should.ps1:180 char:9
            +         throw ( New-ShouldErrorRecord -Message $testResult.FailureMes ...
            +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        395:             {Assert-DatabaseDuplicateIndex -Instance Dummy -Database Dummy1 } | Should -Throw -ExpectedMessage 'Expected 0, because Duplicate indexes waste disk space and cost you extra IO, CPU, and Memory, but got 2.'
        at <ScriptBlock>, D:\a\dbachecks\dbachecks\tests\checks\DatabaseChecks.Tests.ps1: line 395
```
