### PR TITLE
The expected value is a boolean, not a string.

### DIFF
--- a/internal/assertions/Server.Assertions.ps1
+++ b/internal/assertions/Server.Assertions.ps1
@@ -66,19 +66,11 @@ function Get-AllServerInfo {
                     $PowerPlan = (Test-DbaPowerPlan -ComputerName $ComputerName -EnableException -WarningVariable PowerWarning -WarningAction SilentlyContinue).IsBestPractice
                 }
                 catch {
-                    $There = $false
-                    if ($PowerWarning) {
-                        if ($PowerWarning[1].ToString().Contains('Couldn''t resolve hostname')) {
-                            $PowerPlan = 'Could not connect'
-                        }
-                    }
-                    else {
-                        $PowerPlan = 'An Error occurred'
-                    }
+                    $PowerPlan = $false
                 }
             }
             else {
-                $PowerPlan = 'An Error occurred'
+                $PowerPlan = $false
             }
         }
         'SPN' {
@@ -177,11 +169,11 @@ function Get-AllServerInfo {
         Default {}
     }
     [PSCustomObject]@{
-        PowerPlan      = $PowerPlan
-        SPNs           = $SPNs
-        DiskSpace      = $DiskSpace
-        PingComputer   = $PingComputer
-        DiskAllocation = $DiskAllocation
+        PowerPlan         = $PowerPlan
+        SPNs              = $SPNs
+        DiskSpace         = $DiskSpace
+        PingComputer      = $PingComputer
+        DiskAllocation    = $DiskAllocation
         StandardPortCount = $StandardPortCount
     }
 }
@@ -206,7 +198,7 @@ function Assert-DiskAllocationUnit {
 
 function Assert-PowerPlan {
     Param($AllServerInfo)
-    $AllServerInfo.PowerPlan | Should -BeTrue -Because "You want your SQL Server to not be throttled by the Power Plan settings - See https://support.microsoft.com/en-us/help/2207548/slow-performance-on-windows-server-when-using-the-balanced-power-plan"
+    $AllServerInfo.PowerPlan | Should -Be 'True' -Because "You want your SQL Server to not be throttled by the Power Plan settings - See https://support.microsoft.com/en-us/help/2207548/slow-performance-on-windows-server-when-using-the-balanced-power-plan"
 }
 
 function Assert-SPN {
@@ -232,9 +224,9 @@ function Assert-Ping {
             ($AllServerInfo.PingComputer).Count | Should -Be $pingcount -Because "We expect the server to respond to ping"
         }
         Average {
-            if($IsCoreCLR){
+            if ($IsCoreCLR) {
             }
-            else{
+            else {
                 ($AllServerInfo.PingComputer | Measure-Object -Property ResponseTime -Average).Average / $pingcount | Should -BeLessThan $pingmsmax -Because "We expect the server to respond within $pingmsmax"
             }
         }

--- a/internal/assertions/Server.Assertions.ps1
+++ b/internal/assertions/Server.Assertions.ps1
@@ -206,7 +206,7 @@ function Assert-DiskAllocationUnit {
 
 function Assert-PowerPlan {
     Param($AllServerInfo)
-    $AllServerInfo.PowerPlan | Should -Be 'True' -Because "You want your SQL Server to not be throttled by the Power Plan settings - See https://support.microsoft.com/en-us/help/2207548/slow-performance-on-windows-server-when-using-the-balanced-power-plan"
+    $AllServerInfo.PowerPlan | Should -BeTrue -Because "You want your SQL Server to not be throttled by the Power Plan settings - See https://support.microsoft.com/en-us/help/2207548/slow-performance-on-windows-server-when-using-the-balanced-power-plan"
 }
 
 function Assert-SPN {

--- a/tests/checks/ServerChecks.Tests.ps1
+++ b/tests/checks/ServerChecks.Tests.ps1
@@ -652,7 +652,7 @@ Describe "Checking ServerChecks.Tests" {
             $serverInfo.DiskAllocation[0].isSqlDisk| Should -BeTrue
         }
         It "Should get the right results for PowerPlan" {
-            $serverInfo.PowerPlan | Should -Be 'An Error occurred'
+            $serverInfo.PowerPlan | Should -BeFalse
         }
         It "Should get the right results for SPN" {
             $serverInfo.SPNs[0].Error | Should -Be 'An Error occurred'
@@ -771,7 +771,7 @@ Describe "Checking ServerChecks.Tests" {
             $serverInfo.DiskAllocation | Should -BeNullOrEmpty
         }
         It "Should get the right results for PowerPlan" {
-            $serverInfo.PowerPlan | Should -Be 'An Error occurred'
+            $serverInfo.PowerPlan | Should -BeFalse
         }
         It "Should have no results for SPN" {
             $serverInfo.SPNs | Should -BeNullOrEmpty


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR
https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests
Invoke-Pester -show Failed,Describe,Summary .\tests\Unit.Tests.ps1 is clean:
Tests Passed: 2133, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0

## Changes this PR brings

Tiny, one-line bug fix. The original line compares $allServerInfo.PowerPlan to a string 'true', but $allServerInfo.PowerPlan needs to be compared to a boolean true. If you dig deeper, you will see that this gets set in Sever.Assertions.ps1, line 66:
$PowerPlan = (Test-DbaPowerPlan -ComputerName $ComputerName blahblahblah).IsBestPractice

It's a little weird that the 'PowerPlan' in the Server.Assertions.ps1 sets $PowerPlan to a string in the catch{} blocks when Test-DbaPowerPlan fails (for whatever reason) but $PowerPlan is a boolean when Test-DbaPowerPlan succeeds. I _think_ that is OK, for our purposes here.

It's also a little weird that DbaChecks basically says "Your Power Plan is/is not "High Performance"", while I'm not sure that Test-DbaPowerPlan "IsBestPractice" is necessarily looking for plan named "High Performance" . IIRC, some some AMD-specific "go fast as possible" Power Plans are named "High Performance (AMD)" or something along those lines. If you look into the Test-DbaPowerPlan code, it actually is looking for a specific GUID as the 'best plan'-maybe different languages call that plan something besides "High Performance"? ("Alto Rendimiento"?) IOW, we want to use the "IsBestPractice" attribute that Test-DbaPowerPlan provides and not compare (English) strings. 

I think that covers everything.
-d






