### PR TITLE
Check for existence in the Tag list before adding a Tag to the Tag list

### DIFF
--- a/internal/functions/Get-CheckInformation.ps1
+++ b/internal/functions/Get-CheckInformation.ps1
@@ -16,7 +16,9 @@ function Get-CheckInformation {
             if ($checkitem -eq $Group) {}
             elseif ($ExcludeCheck -match $Checkitem) {}
             else {
-                $GroupChecks += $checkitem
+                if (-not $GroupChecks.Contains($checkitem)) {
+                    $GroupChecks += $checkitem
+                }
             }
         }
     }
@@ -43,7 +45,9 @@ function Get-CheckInformation {
             if($GroupChecks -contains $psitem){
     ## BUT - This falls flat when you use a tag for a number of Checks that is not a group (like CIS) in that case all you get in $CheckInfo is CIS and not the relevant unique tags
                 @(Get-DbcCheck -Tag $psitem).ForEach{
-                    $CheckInfo += $psitem.UniqueTag
+                    if (-not $CheckInfo.Contains($psitem.UniqueTag)) {
+                        $CheckInfo += $psitem.UniqueTag
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

Tests Passed: 2133, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0 

## Changes this PR brings

There is existing code that evaluates what tags should be operated on during Invoke-DbaChecks. The list of tags to operate on is returned as an array. Since there are "groups" of tags and "uniquetags" and there is some logical about what can be added as part of a group, it can be that some tags are added more than once. In some cases, tags can be added multiple times. Later, tests are run based on the list of tags. If a tag is in the list twice, the corresponding test is run twice. (If a tag is in the list 42 times, it would be run 42 times and so forth.) This leads to longer execution durations, with no benefit.

This change checks to see if a tag is already in the list before adding it, preventing duplicates.
