### PR TITLE
Remove Replication Startup procedure for test

### DIFF
--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -206,8 +206,24 @@ function Get-AllInstanceInfo {
             if ($There) {
                 try {
                     $SpConfig = Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'ScanForStartupProcedures'
+                    if ($SpConfig.ConfiguredValue -eq 1) {
+                        $query = "
+                            SELECT name
+                            FROM sys.procedures
+                            WHERE OBJECTPROPERTY(OBJECT_ID, 'ExecIsStartup') = 1
+                                AND name <> 'sp_MSrepl_startup'"
+                        $results = Invoke-DbaQuery -SqlInstance $Instance -Query $query
+
+                        if ($results.RowCount -eq 0) {
+                            $Value = $false
+                        } else {
+                            $Value = $true
+                        }
+                    } else {
+                        $Value = $SpConfig.ConfiguredValue
+                    }
                     $ScanForStartupProceduresDisabled = [pscustomobject] @{
-                        ConfiguredValue = $SpConfig.ConfiguredValue
+                        ConfiguredValue = $Value
                     }
                 }
                 catch {

--- a/internal/assertions/Instance.Assertions.ps1
+++ b/internal/assertions/Instance.Assertions.ps1
@@ -206,22 +206,20 @@ function Get-AllInstanceInfo {
             if ($There) {
                 try {
                     $SpConfig = Get-DbaSpConfigure -SqlInstance $Instance -ConfigName 'ScanForStartupProcedures'
-                    if ($SpConfig.ConfiguredValue -eq 1) {
-                        $query = "
-                            SELECT name
-                            FROM sys.procedures
-                            WHERE OBJECTPROPERTY(OBJECT_ID, 'ExecIsStartup') = 1
-                                AND name <> 'sp_MSrepl_startup'"
-                        $results = Invoke-DbaQuery -SqlInstance $Instance -Query $query
 
-                        if ($results.RowCount -eq 0) {
-                            $Value = $false
-                        } else {
-                            $Value = $true
-                        }
+                    $query = "
+                        SELECT name
+                        FROM sys.procedures
+                        WHERE OBJECTPROPERTY(OBJECT_ID, 'ExecIsStartup') = 1
+                            AND name <> 'sp_MSrepl_startup'"
+                    $results = Invoke-DbaQuery -SqlInstance $Instance -Query $query
+
+                    if ($null -eq $results)  {
+                        $Value = 0
                     } else {
                         $Value = $SpConfig.ConfiguredValue
                     }
+
                     $ScanForStartupProceduresDisabled = [pscustomobject] @{
                         ConfiguredValue = $Value
                     }


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

* Exclude startup stored procedure for replication for test so it can past test for CIS compliance, as there is no choice but to have this as a startup procedure when you have replication.