### PR TITLE
Remove unsupported Pester Type - fixes #798

### DIFF
--- a/functions/Invoke-DbcCheck.ps1
+++ b/functions/Invoke-DbcCheck.ps1
@@ -216,7 +216,7 @@ function Invoke-DbcCheck {
         [switch]$AllChecks,
         [switch]$Quiet,
         [object]$PesterOption,
-        [Pester.OutputTypes]$Show = 'All'
+        [string]$Show = 'All'
     )
 
     dynamicparam {


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

[x] There may or may  not be 0 failing Pester tests

## Changes this PR brings

Older versions of Pester such as `3.4.0` do not support the type `[Pester.OutputTypes]`. This changes that to string, and now `Invoke-DbcCheck` runs out the box on machines without newer versions of Pester.

There are no other instances of [Pester] types. Fixes #798