### PR TITLE
So that we can have HADR checks with the latest dbatools properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - fixed typo in Invoke-PerfAndValidateCheck so we know which version we're looking at
+- Updated HADR checks to use dbatools new outputs
 
 ## [3.0.2] - 2025-03-10
 

--- a/source/checks/HADR.Tests.ps1
+++ b/source/checks/HADR.Tests.ps1
@@ -353,32 +353,32 @@ foreach ($clustervm in $clusters) {
             Context "Database availability group status for $($AG.Name) on $clustername" {
                 @($ag.AvailabilityReplicas.Where{ $_.AvailabilityMode -eq 'SynchronousCommit' }).ForEach{
                     @(Get-DbaAgDatabase -SqlInstance $psitem.Name -AvailabilityGroup $Ag.Name).ForEach{
-                        It "Database $($psitem.DatabaseName) should be synchronised on the replica $($psitem.Replica)" {
+                        It "Database $($psitem.Name) should be synchronised on the replica $($psitem.sqlInstance)" {
                             $psitem.SynchronizationState | Should -Be 'Synchronized'  -Because 'The database on the synchronous replica should be synchronised'
                         }
-                        It "Database $($psitem.DatabaseName) should be failover ready on the replica $($psitem.Replica)" {
+                        It "Database $($psitem.Name) should be failover ready on the replica $($psitem.sqlInstance)" {
                             $psitem.IsFailoverReady | Should -BeTrue -Because 'The database on the synchronous replica should be ready to failover'
                         }
-                        It "Database $($psitem.DatabaseName) should be joined on the  replica $($psitem.Replica)" {
+                        It "Database $($psitem.Name) should be joined on the  replica $($psitem.sqlInstance)" {
                             $psitem.IsJoined | Should -BeTrue -Because 'The database on the synchronous replica should be joined to the availability group'
                         }
-                        It "Database $($psitem.DatabaseName) should not be suspended on the replica $($psitem.Replica)" {
+                        It "Database $($psitem.Name) should not be suspended on the replica $($psitem.sqlInstance)" {
                             $psitem.IsSuspended | Should -Be  $False -Because 'The database on the synchronous replica should not be suspended'
                         }
                     }
                 }
                 @($ag.AvailabilityReplicas.Where{ $_.AvailabilityMode -eq 'AsynchronousCommit' }).ForEach{
                     @(Get-DbaAgDatabase -SqlInstance $PSItem.Name -AvailabilityGroup $Ag.Name).ForEach{
-                        It "Database $($psitem.DatabaseName) should be synchronising as it is Async on the secondary replica $($psitem.Replica)" {
+                        It "Database $($psitem.Name) should be synchronising as it is Async on the secondary replica $($psitem.sqlInstance)" {
                             $psitem.SynchronizationState | Should -Be 'Synchronizing' -Because 'The database on the asynchronous secondary replica should be synchronising'
                         }
-                        It "Database $($psitem.DatabaseName) should not be failover ready on the secondary replica $($psitem.Replica)" {
+                        It "Database $($psitem.Name) should not be failover ready on the secondary replica $($psitem.sqlInstance)" {
                             $psitem.IsFailoverReady | Should -BeFalse -Because 'The database on the asynchronous secondary replica should be ready to failover'
                         }
-                        It "Database $($psitem.DatabaseName) should be joined on the secondary replica $($psitem.Replica)" {
+                        It "Database $($psitem.Name) should be joined on the secondary replica $($psitem.sqlInstance)" {
                             $psitem.IsJoined | Should -BeTrue -Because 'The database on the asynchronous secondary replica should be joined to the availability group'
                         }
-                        It "Database $($psitem.DatabaseName) should not be suspended on the secondary replica $($psitem.Replica)" {
+                        It "Database $($psitem.Name) should not be suspended on the secondary replica $($psitem.sqlInstance)" {
                             $psitem.IsSuspended | Should -Be  $False -Because 'The database on the asynchronous secondary replica should not be suspended'
                         }
                     }


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

Whilst running HADR checks I realised that the dbatools commands that we use return different property names now which makes for false negatives