### PR TITLE
Add check for pester v5  - LastFullBackup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - fixed typo in Invoke-PerfAndValidateCheck so we know which version we're looking at
+- New database level check `LastFullBackup`
 
 ## [3.0.2] - 2025-03-10
 

--- a/containers/JessAndBeard.psm1
+++ b/containers/JessAndBeard.psm1
@@ -2379,6 +2379,13 @@ The Tags are the same"
           PassedChange  = 0 # + or - the number of tests passed for v5
           FailedChange  = 0 # + or - the number of tests failed for v5
           SkippedChange = -3 # + or - the number of tests skipped for v5
+          },
+      @{
+          Name          = 'LastFullBackup'
+          RunChange     = +1 # + or - the number of tests run for v5
+          PassedChange  = 0 # + or - the number of tests passed for v5
+          FailedChange  = 0 # + or - the number of tests failed for v5
+          SkippedChange = +1 # + or - the number of tests skipped for v5
       }
   )
   $runchange = 0

--- a/source/checks/Databasev5.Tests.ps1
+++ b/source/checks/Databasev5.Tests.ps1
@@ -319,11 +319,12 @@ Describe  "Foreign keys and check constraints not trusted" -Tag FKCKTrusted, Low
     }
 }
 
+#TODO: test if database is offline or not `IsAccessible` 
 Describe  "Last Full Backup Times" -Tag LastFullBackup, LastBackup, Backup, DISA, Varied -ForEach $InstancesToTest {
     $Skip = ($__dbcconfig | Where-Object Name -EQ 'skip.database.lastfullbackup').Value
     #TODO: also skip secondaries? and read only?    
     Context "Testing last full backups on <_.Name>" {
-        It "Database <_.Name> should have full backups less than <_.ConfigValues.fullmaxdays> on <_.SqlInstance>" -Skip:$skip -ForEach $psitem.Databases.Where{ if ($Database) { $_.Name -in $Database } else { $psitem.ConfigValues.fullbackupexclude -notcontains $psitem.Name } }.Where{if ($psitem.ConfigValues.skipreadonly) { -not $psitem.readonly } else {$psitem} }.Where{if ($psitem.ConfigValues.skipsecondaries) { $psitem.AGReplicaRole -ne 'Secondary' } else {$psitem} } { #TODO: secondary? is that right
+        It "Database <_.Name> should have full backups less than <_.ConfigValues.fullmaxdays> on <_.SqlInstance>" -Skip:$skip -ForEach $psitem.Databases.Where{if ($Database) { $_.Name -in $Database } else { $psitem.ConfigValues.fullbackupexclude -notcontains $psitem.Name } }.Where{if ($psitem.ConfigValues.skipreadonly) { -not $psitem.readonly } else {$psitem} }.Where{if ($psitem.ConfigValues.skipsecondaries) { $psitem.AGReplicaRole -ne 'Secondary' } else {$psitem} } { #TODO: secondary? is that right
             $psitem.LastFullBackup.ToUniversalTime() | Should -BeGreaterThan (Get-Date).ToUniversalTime().AddDays( - ($psitem.ConfigValues.fullmaxdays)) -Because "Taking regular backups is extraordinarily important"
         }
     }

--- a/source/internal/configurations/configuration.ps1
+++ b/source/internal/configurations/configuration.ps1
@@ -18,7 +18,7 @@ $EmailValidationSb = {
 }
 Register-PSFConfigValidation -Name validation.EmailValidation -ScriptBlock $EmailValidationSb
 
-$__dbachecksNotv5 = 'ADUser', 'BuiltInAdmin', 'EngineServiceAdmin', 'FullTextServiceAdmin', 'LocalWindowsGroup', 'PublicPermission', 'SqlBrowserServiceAccount', 'TempDbConfiguration','CertificateExpiration', 'DatabaseExists', 'DatabaseGrowthEvent',  'DatafileAutoGrowthType', 'DisabledIndex', 'DuplicateIndex', 'FileGroupBalanced', 'FutureFileGrowth', 'IdentityUsage', 'LastDiffBackup', 'LastFullBackup', 'LastGoodCheckDb', 'LastLogBackup', 'LogfilePercentUsed', 'LogfileSize', 'MaxDopDatabase', 'OrphanedUser', 'SymmetricKeyEncryptionLevel', 'TestLastBackup', 'TestLastBackupVerifyOnly', 'UnusedIndex', 'PowerPlan', 'SPN', 'DiskCapacity', 'PingComputer', 'CPUPrioritisation', 'DiskAllocationUnit', 'NonStandardPort', 'ServerProtocol', 'OlaInstalled', 'SystemFull', 'UserFull', 'UserDiff', 'UserLog', 'CommandLog', 'SystemIntegrityCheck', 'UserIntegrityCheck', 'UserIndexOptimize', 'OutputFileCleanup', 'DeleteBackupHistory', 'PurgeJobHistory', 'DomainName', 'OrganizationalUnit', 'ClusterHealth', 'LogShippingPrimary', 'LogShippingSecondary'
+$__dbachecksNotv5 = 'ADUser', 'BuiltInAdmin', 'EngineServiceAdmin', 'FullTextServiceAdmin', 'LocalWindowsGroup', 'PublicPermission', 'SqlBrowserServiceAccount', 'TempDbConfiguration','CertificateExpiration', 'DatabaseExists', 'DatabaseGrowthEvent',  'DatafileAutoGrowthType', 'DisabledIndex', 'DuplicateIndex', 'FileGroupBalanced', 'FutureFileGrowth', 'IdentityUsage', 'LastDiffBackup', 'LastGoodCheckDb', 'LastLogBackup', 'LogfilePercentUsed', 'LogfileSize', 'MaxDopDatabase', 'OrphanedUser', 'SymmetricKeyEncryptionLevel', 'TestLastBackup', 'TestLastBackupVerifyOnly', 'UnusedIndex', 'PowerPlan', 'SPN', 'DiskCapacity', 'PingComputer', 'CPUPrioritisation', 'DiskAllocationUnit', 'NonStandardPort', 'ServerProtocol', 'OlaInstalled', 'SystemFull', 'UserFull', 'UserDiff', 'UserLog', 'CommandLog', 'SystemIntegrityCheck', 'UserIntegrityCheck', 'UserIndexOptimize', 'OutputFileCleanup', 'DeleteBackupHistory', 'PurgeJobHistory', 'DomainName', 'OrganizationalUnit', 'ClusterHealth', 'LogShippingPrimary', 'LogShippingSecondary'
 
 Set-PSFConfig -Module dbachecks -Name checks.notv5ready -Value @($__dbachecksNotv5) -Initialize -Description "Checks that have not been converted to v5 yet"
 
@@ -178,7 +178,9 @@ Set-PSFConfig -Module dbachecks -Name policy.database.clrassembliessafeexcludedb
 Set-PSFConfig -Module dbachecks -Name policy.database.pseudosimpleexcludedb -Value @('tempdb', 'model') -Initialize -Description "A List of databases that we do not want to check for pseudosimple recovery modelasd a"
 Set-PSFConfig -Module dbachecks -Name policy.database.contdbautocloseexclude -Value @('msdb') -Initialize -Description "A List of contained database that we we do not want to check for autoclose"
 Set-PSFConfig -Module dbachecks -Name policy.database.contdbsqlauthexclude -Value @() -Initialize -Description "A list of databases that we do not want to check for contained databases with SQL authenticated users"
-Set-PSFConfig -Module dbachecks -Name policy.database.logfilepercentused -Value 75 -Initialize -Description " The % log used we should stay below"
+Set-PSFConfig -Module dbachecks -Name policy.database.logfilepercentused -Value 75 -Initialize -Description "The % log used we should stay below"
+Set-PSFConfig -Module dbachecks -Name policy.database.fullbackupexclude -Value @('tempdb') -Initialize -Description "The list of databases that we do not want to check the date of the last full backup of."
+
 
 # Policy for Ola Hallengren Maintenance Solution
 Set-PSFConfig -Module dbachecks -Name policy.ola.installed -Validation bool -Value $true -Initialize -Description "Checks to see if Ola Hallengren solution is installed"
@@ -344,6 +346,8 @@ Set-PSFConfig -Module dbachecks -Name skip.database.recoverymodel -Validation bo
 Set-PSFConfig -Module dbachecks -Name skip.database.pseudosimple -Validation bool -Value $false -Initialize -Description "Skip the database PseudoSimple recovery model test"
 Set-PSFConfig -Module dbachecks -Name skip.database.pageverify -Validation bool -Value $false -Initialize -Description "Skip the database page verify test"
 Set-PSFConfig -Module dbachecks -Name skip.database.fkcktrusted -Validation bool -Value $false -Initialize -Description "Skip the check for foreign keys and constraints being trusted"
+Set-PSFConfig -Module dbachecks -Name skip.database.lastfullbackup -Validation bool -Value $false -Initialize -Description "Skip the check for last full backup"
+
 
 Set-PSFConfig -Module dbachecks -Name skip.logshiptesting -Validation bool -Value $false -Initialize -Description "Skip the logshipping test"
 

--- a/source/internal/functions/Get-AllDatabaseInfo.ps1
+++ b/source/internal/functions/Get-AllDatabaseInfo.ps1
@@ -217,7 +217,7 @@ function Get-AllDatabaseInfo {
                 ForeignKeys               = @(if ($trusted) {$psitem.Tables.ForeignKeys | Where-Object {-not $_.NotForReplication} | Select-Object Name, Parent, @{l='Database';e={$_.Parent.Parent.Name}}, IsChecked } )
                 Constraints               = @(if ($trusted) {$psitem.Tables.Checks | Where-Object {(-not $_.NotForReplication) -and $_.IsEnabled} | Select-Object Name, Parent, @{l='Database';e={$_.Parent.Parent.Name}}, IsChecked } )
                 LastFullBackup            = @(if ($lastFullBackup) {$psitem.LastBackupDate})
-                AGReplicaRole             = @(if ($lastFullBackup) { if ($psitem.AvailabilityGroupName) {$psitem.parent.AvailabilityGroups[$psitem.AvailabilityGroupName].LocalReplicaRole}}) # TODO: this needs testing!   
+                AGReplicaRole             = @(if ($lastFullBackup) { if ($psitem.AvailabilityGroupName) {$psitem.parent.AvailabilityGroups[$psitem.AvailabilityGroupName].LocalReplicaRole} else { 'N\A' }}) # TODO: this needs testing!   
             }
         }
     }


### PR DESCRIPTION
## LastFullBackup

### Changes

Do we think this is acceptable, in the new world if you set this config to `$true` you won't see the readonly databases that got skipped in the output. Is that fine? or should we code it in a way where we still see that there were readonly databases skipped? (due to how Pester v5 does skipping, I'm not sure how easy it'll be to get the database name in the skip output, but we would know something was skipped 🤔)

```text
PS > Get-DbcConfig skip.backup.readonly

Name                 Value Description
----                 ----- -----------
skip.backup.readonly  True Check read-only databases for last backup
```

![image](https://github.com/user-attachments/assets/e719f840-1088-4d3b-9450-585fead7ceee)
