### PR TITLE
Update Set-DbcCisConfig.ps1

### DIFF
--- a/source/functions/Set-DbcCisConfig.ps1
+++ b/source/functions/Set-DbcCisConfig.ps1
@@ -32,7 +32,7 @@ function Set-DbcCisConfig {
         Set-DbcConfig -Name policy.dacallowed -Value $false
         Set-DbcConfig -Name policy.errorlog.logcount -Value 12
         Set-DbcConfig -Name policy.security.oleautomationproceduresdisabled -Value $false
-        Set-DbcConfig -Name policy.oleautomation -Value 0
+        Set-DbcConfig -Name policy.oleautomation -Value $false
         Set-DbcConfig -Name policy.security.adhocdistributedqueriesenabled -Value $false
         Set-DbcConfig -Name policy.security.clrenabled -Value $false
         Set-DbcConfig -Name policy.security.databasemailenabled -Value $false


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[X] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)

- function Set-DbcCisConfig:  policy.oleautomation settings to $false instead of 0 because it needs an boolean