### PR TITLE
Bug fixes for HADR checks

### DIFF
--- a/source/checks/HADR.Tests.ps1
+++ b/source/checks/HADR.Tests.ps1
@@ -37,7 +37,7 @@ function Get-ClusterObject {
                 $PreviousClusterNode = $AGResource.OwnerNode.Name
                 # We get cluster node owner first ...
                 # We need then for each owner to find out the corresponding replicas => SQL Instance Name + Port
-                $Replicas = Find-DbaInstance -ComputerName $AGResource.OwnerNode.Name
+                $Replicas = Find-DbaInstance -ComputerName $AGResource.OwnerNode.Name | Where-Object {$_.Services.ServiceName -ne $null }
             }
 
             # Finally for each replica detected (SQL Server + Port)

--- a/source/checks/HADR.Tests.ps1
+++ b/source/checks/HADR.Tests.ps1
@@ -53,7 +53,7 @@ function Get-ClusterObject {
             }
         }
         catch {
-            $return = $null
+            $return.AvailabilityGroups[$AGResource.Name] = 'FailedToConnect'
         }
     }
 


### PR DESCRIPTION
## Changes this PR brings

- fixed error in getting AO details when running on a machine with multiple named instances (each instance with 1 AG)
- fixed empty cluster object when getting internal AO error


Remarks: 
I tried following the instructions on how to test a PR, but did not manage to get the required result. The instructions were confusing for me: 
- no folder .\tests available, changing it to .\checks did a little bit better
- Get-ManifestValue was not recognised, but changed the requiredversions parameter with fixed-values
- Exclusions of "integration" tags while we would want them to run? 
- tests then seemed to execute all checks on the SqlInstance values of my last check. It did execute, but of course some of the checks fails (because which server would be 100% ok in the real world :) )

I did test these changes in a custom version of HADR.Test1 file that I include in my DbaChecks project, they work there now and much less failed tests for that one server I had trouble with.